### PR TITLE
Feat/e2e tests _Add live end-to-end tests + CI integration_

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,9 @@ jobs:
           cd packages/aid-go
           go test ./...
 
+      - name: E2E Tests
+        run: pnpm e2e
+
       - name: Generate SBOM (CycloneDX)
         uses: CycloneDX/gh-node-module-generatebom@v1
         with:

--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ It uses a single DNS `TXT` record to make any agent service—whether it speaks 
 
 ```bash
 # A user wants to use Supabase's agent. They only know the domain.
-$ npx @agentcommunity/aid-doctor check supabase.com
+$ npx @agentcommunity/aid-doctor check supabase.agentcommunity.org
 
-✅ AID Record Found for _agent.supabase.com
+✅ AID Record Found for _agent.supabase.agentcommunity.org
    Protocol:    mcp
    URI:         https://api.supabase.com/mcp
    Auth Hint:   pat
-   Description: Supabase Database Tools
+   Description: (Community Showcase)
 ```
 
 **Zero configuration. Universal compatibility. Just DNS.**
@@ -57,11 +57,11 @@ import { discover, AidError } from '@agentcommunity/aid';
 
 try {
   // Discover any agent by domain
-  const { record, ttl } = await discover('supabase.com');
+  const { record, ttl } = await discover('supabase.agentcommunity.org');
   console.log(`Found ${record.proto} agent at ${record.uri}`);
   console.log(`Record TTL: ${ttl} seconds`);
   //=> Found mcp agent at https://api.supabase.com/mcp
-  //=> Record TTL: 300 seconds
+  //=> Record TTL: 60 seconds
 } catch (error) {
   if (error instanceof AidError) {
     // Handle specific errors like NoRecordFound, InvalidRecord, etc.
@@ -77,7 +77,7 @@ import { discover, AidError } from '@agentcommunity/aid/browser';
 
 try {
   // Uses DNS-over-HTTPS for browser compatibility
-  const { record } = await discover('supabase.com');
+  const { record } = await discover('supabase.agentcommunity.org');
   console.log(`Found ${record.proto} agent at ${record.uri}`);
 } catch (error) {
   if (error instanceof AidError) {
@@ -91,7 +91,7 @@ try {
 AID uses a well-known DNS `TXT` record at `_agent.<domain>`.
 
 ```dns
-_agent.example.com. 300 IN TXT "v=aid1;uri=https://api.example.com/mcp;p=mcp;auth=pat;desc=AI Tools"
+_agent.supabase.agentcommunity.org. 60 IN TXT "v=aid1;uri=https://api.supabase.com/mcp;proto=mcp;auth=pat;desc=(Community Showcase)"
 ```
 
 The client queries this record, parses the `key=value` pairs, and uses the `uri` to connect. That's it. For full details, see the [**Full Specification**](./packages/docs/specification.md).
@@ -141,6 +141,9 @@ cd packages/aid-go && go test ./...
 
 # Lint all code
 pnpm lint
+
+# Run end-to-end tests against live showcase records
+pnpm e2e
 ```
 
 ### Project Structure

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "docs:sync": "turbo run sync:docs",
     "dev": "turbo run dev --parallel",
     "clean": "turbo run clean",
-    "gen": "tsx scripts/generate-constants.ts"
+    "gen": "tsx scripts/generate-constants.ts",
+    "e2e": "turbo run e2e"
   },
   "devDependencies": {
     "@changesets/cli": "^2.29.5",

--- a/packages/aid-doctor/src/cli.ts
+++ b/packages/aid-doctor/src/cli.ts
@@ -1,8 +1,12 @@
 #!/usr/bin/env node
 
 import { Command } from 'commander';
-import { discover, AidError, type DiscoveryResult } from '@agentcommunity/aid';
-import { enforceRedirectPolicy } from '@agentcommunity/aid/src/security.js';
+import {
+  discover,
+  AidError,
+  enforceRedirectPolicy,
+  type DiscoveryResult,
+} from '@agentcommunity/aid';
 import chalk from 'chalk';
 import ora from 'ora';
 

--- a/packages/e2e-tests/package.json
+++ b/packages/e2e-tests/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@agentcommunity/e2e-tests",
+  "private": true,
+  "version": "0.0.0",
+  "description": "End-to-End tests for live showcase AID records",
+  "scripts": {
+    "e2e": "tsx src/e2e.ts"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "@agentcommunity/aid-doctor": "workspace:*",
+    "tsx": "^4.20.3"
+  }
+}

--- a/packages/e2e-tests/src/e2e.ts
+++ b/packages/e2e-tests/src/e2e.ts
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * List of showcase domains to validate. These correspond to the
+ * `locals.records` entries in `showcase/terraform/main.tf` (minus the _agent prefix).
+ */
+const DOMAINS: readonly string[] = [
+  'simple.agentcommunity.org',
+  'local-docker.agentcommunity.org',
+  'messy.agentcommunity.org',
+  'multi-string.agentcommunity.org',
+  'supabase.agentcommunity.org',
+  'auth0.agentcommunity.org',
+  'openai.agentcommunity.org',
+] as const;
+
+const TIMEOUT_MS = 15_000;
+
+let failures = 0;
+
+for (const domain of DOMAINS) {
+  console.log(`\n🚀 Testing AID discovery for ${domain}...`);
+
+  const __filename = fileURLToPath(import.meta.url);
+  const __dirnameResolved = path.dirname(__filename);
+  const cliPath = path.resolve(__dirnameResolved, '../../aid-doctor/dist/cli.js');
+
+  const result = spawnSync(
+    'node',
+    [
+      '--no-warnings',
+      '--experimental-modules',
+      cliPath,
+      'check',
+      domain,
+      '--timeout',
+      String(TIMEOUT_MS),
+    ],
+    {
+      stdio: 'inherit',
+      shell: false,
+    },
+  );
+
+  if (result.error) {
+    console.error(`❌ Failed to spawn aid-doctor for ${domain}:`, result.error);
+    failures++;
+    continue;
+  }
+
+  if (result.status === 0) {
+    console.log(`✅ Success for ${domain}`);
+  } else {
+    console.error(`❌ aid-doctor exited with code ${result.status} for ${domain}`);
+    failures++;
+  }
+}
+
+if (failures > 0) {
+  console.error(`\n❌ E2E tests failed for ${failures} domain(s).`);
+  process.exit(1);
+}
+
+console.log('\n🎉 All E2E tests passed!');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,6 +106,18 @@ importers:
         specifier: ^2.0.0
         version: 2.1.9(@types/node@22.16.0)
 
+  packages/e2e-tests:
+    devDependencies:
+      '@agentcommunity/aid-doctor':
+        specifier: workspace:*
+        version: link:../aid-doctor
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.16.0
+      tsx:
+        specifier: ^4.20.3
+        version: 4.20.3
+
 packages:
   /@babel/helper-validator-identifier@7.27.1:
     resolution:

--- a/showcase/terraform/main.tf
+++ b/showcase/terraform/main.tf
@@ -16,7 +16,7 @@ provider "vercel" {}
 ########################
 
 variable "zone" {
-  description = "Apex DNS zone managed in Vercel (e.g., agentcommunity.org)"
+  description = "The apex domain managed by Vercel (agentcommunity.org)"
   type        = string
 }
 
@@ -34,35 +34,34 @@ locals {
   record_prefix = "_agent"
 
   records = {
+    # The name is now the full subdomain string that will be created
+    # on top of the 'zone' (e.g., _agent.simple.agentcommunity.org)
     simple = {
-      # The name is now just the unique part of the subdomain.
-      # The full name will be constructed by Vercel as:
-      # _agent.simple.showcase.aid.agentcommunity.org
-      name  = "${local.record_prefix}.simple.showcase.aid"
+      name  = "${local.record_prefix}.simple"
       value = "v=aid1;uri=https://api.example.com/mcp;p=mcp"
     }
     local_docker = {
-      name  = "${local.record_prefix}.local-docker.showcase.aid"
+      name  = "${local.record_prefix}.local-docker"
       value = "v=aid1;uri=docker://myimage;proto=local;desc=Local Docker Agent"
     }
     messy = {
-      name  = "${local.record_prefix}.messy.showcase.aid"
+      name  = "${local.record_prefix}.messy"
       value = " v=aid1 ; uri=https://api.example.com/mcp ; p=mcp ; extra=ignored "
     }
     multi_string = {
-      name  = "${local.record_prefix}.multi-string.showcase.aid"
+      name  = "${local.record_prefix}.multi-string"
       value = "v=aid1;uri=https://api.example.com/mcp;p=mcp;desc=Multi string part 1"
     }
     supabase = {
-      name  = "${local.record_prefix}.supabase.showcase.aid"
+      name  = "${local.record_prefix}.supabase"
       value = "v=aid1;uri=https://api.supabase.com/mcp;proto=mcp;auth=pat;desc=(Community Showcase)"
     }
     auth0 = {
-      name  = "${local.record_prefix}.auth0.showcase.aid"
+      name  = "${local.record_prefix}.auth0"
       value = "v=aid1;uri=https://ai.auth0.com/mcp;proto=mcp;auth=pat;desc=(Community Showcase)"
     }
     openai = {
-      name  = "${local.record_prefix}.openai.showcase.aid"
+      name  = "${local.record_prefix}.openai"
       value = "v=aid1;uri=https://api.openai.com/v1/assistants;proto=openapi;desc=OpenAI Assistants API"
     }
   }
@@ -72,8 +71,12 @@ locals {
 resource "vercel_dns_record" "showcase" {
   for_each = local.records
 
+  # The 'domain' is our main apex domain
   domain    = var.zone
+
+  # The 'name' is the subdomain part
   name      = each.value.name
+  
   type      = "TXT"
   value     = each.value.value
   team_id   = var.team_id

--- a/tracking/PHASE_2.md
+++ b/tracking/PHASE_2.md
@@ -11,14 +11,16 @@ Started: 2025-07-06
 - **[2025-07-06]** Added cross-language parity tests (`parity.*`) reading shared `test-fixtures/golden.json`; implemented in TypeScript, Python & Go – all pass locally.
 - **[2025-07-06]** Scaffolded Vercel DNS IaC: added `showcase/terraform/main.tf` (Terraform + vercel provider) and GitHub Actions workflow `showcase-dns.yml` for plan/apply.
 - **[2025-07-06]** Finalised showcase TXT records (7 total) in `showcase/terraform/main.tf` – simple, local-docker, messy, multi-string, supabase, auth0, openai.
+- **[2025-07-07]** Deployed live showcase DNS records to production on `agentcommunity.org` using Terraform and GitHub Actions after resolving Vercel provider issues. All 7 showcase records are now live and verifiable via `dig`.
+- **[2025-07-07]** Added live E2E test suite (`packages/e2e-tests`) and integrated into Turbo + CI. All 7 showcase domains validated successfully.
 
 ## Next Milestones (Planned)
 
-1. **Showcase DNS Zone (`showcase.aid.agentcommunity.org`)**
-   - Register / configure sub-domain in DNS provider.
-   - Publish the 6 planned reference records (simple, local-docker, messy, multi-string, supabase, auth0).
-   - Add Terraform (or Cloudflare) infrastructure-as-code so records are version-controlled.
-2. **E2E Test Suite (`e2e/` workspace)**
+1. **Showcase DNS Zone (`showcase.aid.agentcommunity.org`)** ✅ **Done**
+   - ~~Register / configure sub-domain in DNS provider.~~
+   - Published the 7 planned reference records (simple, local-docker, messy, multi-string, supabase, auth0, openai) to the apex domain `agentcommunity.org`.
+   - Terraform Infrastructure-as-code is live and managing all records.
+2. **E2E Test Suite (`e2e/` workspace)** ✅ **Done**
    - New Turbo pipeline: `turbo run e2e`.
    - Tests invoke CLI (`aid-doctor`) against live showcase records and assert `exit 0`.
    - Run nightly in CI; fail build on regression.

--- a/turbo.json
+++ b/turbo.json
@@ -19,6 +19,11 @@
     "clean": {
       "cache": false,
       "outputs": []
+    },
+    "e2e": {
+      "dependsOn": ["build", "^build"],
+      "cache": false,
+      "outputs": []
     }
   }
 }


### PR DESCRIPTION

### What / Why
| Item | Details |
|------|---------|
| **Goal** | Guarantee the showcase TXT records stay valid and that the Node CLI continues to parse them. |
| **Scope** | New workspace `packages/e2e-tests`, Turbo pipeline task, CI job, README update. |
| **Risk** | Minimal – tests are read-only DNS look-ups & HTTP HEAD checks. |
| **Benefit** | Fails CI immediately if a DNS record disappears or a parsing regression is introduced. |

### Implementation notes
1. **Workspace:**  
   `packages/e2e-tests` with lightweight `package.json` and a single `src/e2e.ts`.
2. **Runner:**  
   Script iterates over all 7 showcase domains, spawns the built `aid-doctor` CLI (`node --experimental-modules packages/aid-doctor/dist/cli.js check …`).  
   • Non-zero exit → test failure; aggregated at the end.  
3. **Turbo:**  
   Added `e2e` task (`dependsOn: [ "build", "^build" ]`) so all packages are compiled first.  
4. **CI:**  
   `.github/workflows/ci.yml` new “E2E Tests” step (runs after Go tests).  
5. **Docs:**  
   README now lists `pnpm e2e` in the Dev guide.  
6. **Lint:**  
   Fixed `unicorn/import-style` & `__dirname` issues; passes.

### Checklist
- [x] Added/updated tests
- [x] Ran `turbo run build test lint e2e`
- [x] Added a Changeset _(NA – internal tooling)_
- [x] Updated docs (README)
- [x] Updated `tracking/PHASE_2.md` file  
  (_“E2E Test Suite” now **Done** – done in earlier commit_)

