### PR TITLE
chore(release): trigger PyPI publish for aid-discovery v1.0.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - 'packages/**/package.json'
+      - 'packages/**/pyproject.toml'
       - 'CHANGELOG.md'
       - '.changeset/**'
 


### PR DESCRIPTION
- [x] Added/updated tests
- [ ] Ran `turbo run build test lint`
- [ ] Added a Changeset
- [ ] Updated docs if public API changed
- [ ] Updated relevant `tracking/PHASE_X.md` file

Does this adhere to `.cursorrule`?
