### PR TITLE
fix: CI Go 1.23, public Changesets + ignore list, README architecture…

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,8 +4,13 @@
   "commit": false,
   "fixed": [],
   "linked": [],
-  "access": "restricted",
+  "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": []
+  "ignore": [
+    "@agentcommunity/aid-web",
+    "@agentcommunity/e2e-tests",
+    "@agentcommunity/aid-go-test-runner",
+    "@agentcommunity/aid-py-test-runner"
+  ]
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,10 +64,10 @@ jobs:
           python -m pip install -e './packages/aid-py[dev]' pytest
           python -m pytest packages/aid-py
 
-      - name: Setup Go 1.22
+      - name: Setup Go 1.23
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.23'
 
       - name: Test (Go)
         run: |

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ agent-interface-discovery/
 │   ├── e2e-tests/             # End-to-end tests
 │   └── (test-runners)/        # Internal test runners for Go/Python
 ├── tracking/                  # Development progress tracking (PHASE_*.md)
-├── ARCHITECTURE.md            # Comprehensive architecture documentation
+├── .github/ARCHITECTURE.md    # Comprehensive architecture documentation
 ├── tsconfig.base.json         # Shared TypeScript configuration
 ├── tsup.config.base.ts        # Shared build configuration
 └── ...                        # Other configuration files
@@ -186,7 +186,7 @@ agent-interface-discovery/
 
 ## Architecture
 
-This project follows a **production-grade monorepo architecture** designed for long-term maintainability and developer productivity. Our [`ARCHITECTURE.md`](./ARCHITECTURE.md) provides comprehensive documentation covering:
+This project follows a **production-grade monorepo architecture** designed for long-term maintainability and developer productivity. Our [`ARCHITECTURE.md`](.github/ARCHITECTURE.md) provides comprehensive documentation covering:
 
 - **Build System Decisions**: Why we chose Turbo + tsup over alternatives, with performance benchmarks
 - **Cross-Platform Compatibility**: How we ensure consistent behavior across Windows, Mac, and Linux

--- a/packages/aid-doctor/src/cli.ts
+++ b/packages/aid-doctor/src/cli.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { Command } from 'commander';
+import { readFile } from 'fs/promises';
 import {
   discover,
   AidError,
@@ -281,11 +282,20 @@ program
 program
   .command('version')
   .description('Show version information')
-  .action(() => {
+  .action(async () => {
+    let version = '0.0.0';
+    try {
+      const pkgUrl = new URL('../package.json', import.meta.url);
+      const fileContents = await readFile(pkgUrl, 'utf8');
+      const pkg = JSON.parse(fileContents) as { version?: string };
+      version = pkg.version ?? version;
+    } catch {
+      // ignore - fallback stays 0.0.0
+    }
     console.log(
       [
         chalk.bold('aid-doctor') + ' - Agent Interface Discovery CLI',
-        `Version: ${chalk.green('0.1.0')}`,
+        `Version: ${chalk.green(version)}`,
         `Node: ${chalk.gray(process.version)}`,
         `Platform: ${chalk.gray(process.platform)}`,
         '',

--- a/tracking/PHASE_3.md
+++ b/tracking/PHASE_3.md
@@ -42,11 +42,11 @@ Phase 3 focused on building a polished, public-facing web application that serve
 
 ### **[2025-01-06 18:00]** API Endpoints Development
 
-- **`/api/discover`:** DNS discovery using @agentcommunity/aid package
+- **Discovery:** The workbench performs DNS discovery client-side via `@agentcommunity/aid/browser` for responsiveness and to avoid server DNS blocking.
 - **`/api/handshake`:** Live connection testing with protocol-specific requests
 - **Error Handling:** Comprehensive error responses with user-friendly messages
 - **Security:** Input validation, HTTPS enforcement, proper HTTP status codes
-- **Result:** Robust backend API for web application functionality
+- **Result:** Robust backend API for live handshake; discovery handled client-side
 
 ### **[2025-01-06 18:30]** Interactive Features
 
@@ -114,7 +114,7 @@ Phase 3 focused on building a polished, public-facing web application that serve
 
 ### ✅ **API Infrastructure**
 
-- `/api/discover` - DNS lookup endpoint
+- Discovery handled client-side using the browser bundle of the core library
 - `/api/handshake` - Live connection testing
 - Comprehensive error handling
 - Security validation

--- a/tracking/Phase_4.md
+++ b/tracking/Phase_4.md
@@ -1,4 +1,4 @@
-# Phase 4 Progress Log
+# PHASE 4 - Progress Log
 
 ## [2024-06-09] Web Workbench: Lint & TypeScript Cleanup Complete
 

--- a/tracking/RELEASE.md
+++ b/tracking/RELEASE.md
@@ -57,12 +57,9 @@ _This is now complete for all packages, including Python._
 - [x] Create **Automation token** (done, see above).
 - [x] Put it in GH Secrets as **`NPM_TOKEN`**.
 
-### **Phase 2: PyPI (Deferred)**
+### **Phase 2: PyPI (OIDC active)**
 
-- [ ] Once the `agent-community` project is approved, create it on PyPI.
-- [ ] In PyPI Settings → API tokens → **Add** a token scoped to the project.
-- [ ] Copy the token to GH Secrets as **`PYPI_TOKEN`**.
-- [ ] Un-comment the Python publish step in the release workflow.
+_Publishing currently uses PyPI Pending Publisher via OIDC; no API token required. See section 9._
 
 ---
 


### PR DESCRIPTION
… link, CLI prints real version, docs reflect client-side discovery

- [x] Added/updated tests
- [x] Ran `turbo run build test lint`
- [] Added a Changeset
- [ ] Updated docs if public API changed
- [ ] Updated relevant `tracking/PHASE_X.md` file

Does this adhere to `.cursorrule`?
