### PR TITLE
ci(parity-gates): add parity job and root test:parity script (TS/Py/G…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,32 @@ jobs:
       - name: E2E Tests
         run: pnpm e2e
 
+  parity:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup PNPM
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Setup Python 3.11
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Setup Go 1.23
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+      - name: Run parity tests (TS/Py/Go)
+        run: pnpm test:parity
+
       # ---- SBOM ------------------------------------------------------------
       - name: Generate SBOM (CycloneDX)
         uses: CycloneDX/gh-node-module-generatebom@v1

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "dev:all": "turbo run dev --parallel",
     "build": "turbo run build",
     "test": "turbo run test",
+    "test:parity": "pnpm -C packages/aid run test && pnpm -C packages/aid-go run test && python3 -m pip install -e './packages/aid-py[dev]' && python3 -m pytest packages/aid-py",
     "lint": "turbo run lint",
     "clean": "turbo run clean",
     "one-shot": "eslint --cache --max-warnings 0 .",


### PR DESCRIPTION
…o)\n\n- CI parity job with Node+Python+Go setup\n- Root script runs TS, Go, and Python parity tests\n- No secrets required, caching retained

- [x] Added/updated tests
- [x] Ran `turbo run build test lint`
- [x] Added a Changeset
- [ ] Updated docs if public API changed
- [ ] Updated relevant `tracking/PHASE_X.md` file

Does this adhere to `.cursorrule`?
