### PR TITLE
chore(tooling): add spec 1.2 enterprise issue opener

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "docs:export": "node scripts/docs-export.mjs",
     "docs:verify": "pnpm docs:check && pnpm docs:export && git diff --exit-code packages/docs/export-manifest.json packages/docs/export-manifest.sha256",
     "e2e": "turbo run e2e",
+    "issues:spec12:enterprise": "node scripts/open-spec-1.2-enterprise-hardening-issues.mjs --apply",
     "changeset": "changeset",
     "version-packages": "changeset version",
     "release": "changeset publish",

--- a/scripts/open-spec-1.2-enterprise-hardening-issues.mjs
+++ b/scripts/open-spec-1.2-enterprise-hardening-issues.mjs
@@ -1,0 +1,238 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+
+const PLAN_FILE = 'tracking/SPEC_1.2_ENTERPRISE_HARDENING_ISSUES.md';
+const DEFAULT_REPO = 'agentcommunity/agent-identity-discovery';
+
+const args = new Set(process.argv.slice(2));
+const apply = args.has('--apply');
+const repoArgIndex = process.argv.indexOf('--repo');
+const repo =
+  repoArgIndex > -1 && process.argv[repoArgIndex + 1]
+    ? process.argv[repoArgIndex + 1]
+    : process.env.GITHUB_REPOSITORY || DEFAULT_REPO;
+
+function runGh(ghArgs, input) {
+  const result = spawnSync('gh', ghArgs, {
+    encoding: 'utf8',
+    input,
+  });
+  if (result.status !== 0) {
+    const cmd = `gh ${ghArgs.join(' ')}`;
+    const stderr = result.stderr?.trim();
+    throw new Error(`${cmd} failed${stderr ? `: ${stderr}` : ''}`);
+  }
+  return result.stdout.trim();
+}
+
+function runGhJson(ghArgs) {
+  const output = runGh(ghArgs);
+  return output ? JSON.parse(output) : [];
+}
+
+function parseIssueSections(markdown) {
+  const sections = [];
+  const headerRegex = /^## ISSUE (\d+)(?:\s+\(([^)]+)\))?/gm;
+  const matches = [...markdown.matchAll(headerRegex)];
+
+  for (const [index, match] of matches.entries()) {
+    const start = match.index ?? 0;
+    const end = index + 1 < matches.length ? matches[index + 1].index : markdown.length;
+    const sectionText = markdown.slice(start, end);
+    const number = Number.parseInt(match[1], 10);
+    const tracker = (match[2] || '').toLowerCase().includes('tracker');
+
+    const titleMatch = sectionText.match(/Title:\s*\n`([^`]+)`/);
+    const bodyMatch = sectionText.match(/Body:\s*\n```md\n([\s\S]*?)\n```/);
+    const labelsSectionMatch = sectionText.match(
+      /Suggested labels:\s*\n([\s\S]*?)(?:\n\n(?:Controversy level:|---|## ISSUE|$))/,
+    );
+    const labelMatches = labelsSectionMatch
+      ? [...labelsSectionMatch[1].matchAll(/^\s*-\s*`([^`]+)`\s*$/gm)]
+      : [];
+
+    if (!titleMatch || !bodyMatch) {
+      throw new Error(`Unable to parse ISSUE ${number} from ${PLAN_FILE}.`);
+    }
+
+    sections.push({
+      number,
+      tracker,
+      title: titleMatch[1].trim(),
+      body: bodyMatch[1].trim(),
+      labels: labelMatches.map((labelMatch) => labelMatch[1].trim()),
+    });
+  }
+
+  return sections.sort((a, b) => a.number - b.number);
+}
+
+function parseIssueNumber(issueUrl) {
+  const match = issueUrl.match(/\/issues\/(\d+)\s*$/);
+  if (!match) {
+    throw new Error(`Could not parse issue number from URL: ${issueUrl}`);
+  }
+  return Number.parseInt(match[1], 10);
+}
+
+function labelColor(name) {
+  const colors = {
+    spec: '0052CC',
+    enterprise: '5319E7',
+    tracking: 'FBCA04',
+    discovery: '1D76DB',
+    security: 'D93F0B',
+    conformance: '0E8A16',
+    'sdk-parity': '1D76DB',
+    parser: 'BFD4F2',
+    format: 'A2EEEF',
+    tooling: 'F9D0C4',
+  };
+  return colors[name] || '1F6FEB';
+}
+
+function ensureLabels(specs) {
+  const required = new Set(specs.flatMap((spec) => spec.labels));
+  const existing = new Set(
+    runGhJson(['label', 'list', '--repo', repo, '--limit', '500', '--json', 'name']).map((label) => label.name),
+  );
+
+  for (const label of required) {
+    if (existing.has(label)) continue;
+    if (!apply) continue;
+    runGh([
+      'label',
+      'create',
+      label,
+      '--repo',
+      repo,
+      '--color',
+      labelColor(label),
+      '--description',
+      `Label used by ${PLAN_FILE}`,
+    ]);
+    existing.add(label);
+  }
+
+  return existing;
+}
+
+function createIssue(spec, availableLabels, bodyOverride) {
+  const body = bodyOverride ?? spec.body;
+  const cmd = ['issue', 'create', '--repo', repo, '--title', spec.title, '--body-file', '-'];
+  for (const label of spec.labels.filter((value) => availableLabels.has(value))) {
+    cmd.push('--label', label);
+  }
+
+  if (!apply) {
+    return {
+      title: spec.title,
+      number: null,
+      url: '(dry-run)',
+      created: false,
+      simulated: true,
+    };
+  }
+
+  const url = runGh(cmd, body);
+  return {
+    title: spec.title,
+    number: parseIssueNumber(url),
+    url,
+    created: true,
+    simulated: false,
+  };
+}
+
+function main() {
+  const planPath = path.resolve(process.cwd(), PLAN_FILE);
+  const markdown = fs.readFileSync(planPath, 'utf8');
+  const specs = parseIssueSections(markdown);
+  const tracker = specs.find((spec) => spec.tracker || spec.number === 0);
+  const children = specs.filter((spec) => spec !== tracker);
+
+  if (!tracker) {
+    throw new Error(`No tracker issue found in ${PLAN_FILE}.`);
+  }
+
+  const availableLabels = ensureLabels(specs);
+  const existingIssues = runGhJson([
+    'issue',
+    'list',
+    '--repo',
+    repo,
+    '--state',
+    'all',
+    '--limit',
+    '500',
+    '--json',
+    'number,title,url',
+  ]);
+  const existingByTitle = new Map(existingIssues.map((issue) => [issue.title, issue]));
+
+  const childResults = [];
+  for (const child of children) {
+    const existing = existingByTitle.get(child.title);
+    if (existing) {
+      childResults.push({
+        title: child.title,
+        number: existing.number,
+        url: existing.url,
+        created: false,
+        simulated: false,
+      });
+      continue;
+    }
+
+    const created = createIssue(child, availableLabels);
+    if (created.number) {
+      existingByTitle.set(child.title, created);
+    }
+    childResults.push(created);
+  }
+
+  let placeholderIndex = 0;
+  const trackerBody = tracker.body.replace(/#TBD/g, () => {
+    const child = childResults[placeholderIndex];
+    placeholderIndex += 1;
+    if (!child) return '#TBD';
+    if (!child.number) return `#ISSUE_${placeholderIndex}`;
+    return `#${child.number}`;
+  });
+
+  const existingTracker = existingByTitle.get(tracker.title);
+  const trackerResult = existingTracker
+    ? {
+        title: tracker.title,
+        number: existingTracker.number,
+        url: existingTracker.url,
+        created: false,
+        simulated: false,
+      }
+    : createIssue(tracker, availableLabels, trackerBody);
+
+  console.log(`Repo: ${repo}`);
+  console.log(`Plan: ${PLAN_FILE}`);
+  console.log(`Mode: ${apply ? 'apply' : 'dry-run'}`);
+  console.log('');
+  console.log('Child issues:');
+  for (const issue of childResults) {
+    const status = issue.created ? 'created' : issue.simulated ? 'would create' : 'existing';
+    console.log(`- [${status}] ${issue.title} -> ${issue.url}`);
+  }
+  console.log('');
+  {
+    const status = trackerResult.created
+      ? 'created'
+      : trackerResult.simulated
+        ? 'would create'
+        : 'existing';
+    console.log(`Tracker: [${status}] ${trackerResult.title} -> ${trackerResult.url}`);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- add a reusable script to open the SPEC 1.2 enterprise hardening issue set from `tracking/SPEC_1.2_ENTERPRISE_HARDENING_ISSUES.md`
- add `pnpm issues:spec12:enterprise` script entry to run it
- make creation idempotent by reusing existing issue titles and creating missing labels automatically

## Notes
- intentionally leaves local `packages/web/next-env.d.ts` uncommitted since it is build-generated
- issues #92-#97 were already created using this script
