### PR TITLE
docs(quickstart): add key legend and SDK field-mapping note

### DIFF
--- a/packages/docs/quickstart/index.md
+++ b/packages/docs/quickstart/index.md
@@ -60,6 +60,8 @@ v=aid1;uri=https://api.my-cool-saas.com/agent/v1;p=mcp;desc=My Cool SaaS AI
 
 **Plus validation:** The CLI automatically validates your record format, URI scheme, and protocol tokens before generating.
 
+> **Key reference:** AID records use single-letter keys for compactness. `v`=version, `u`=uri, `p`=protocol, `a`=auth, `s`=description, `d`=docs url, `e`=deprecation, `k`=public key, `i`=key id. You don't need to memorize these — the CLI and [Live Generator](https://aid.agentcommunity.org/workbench) handle it for you. See the [full key table](../specification.md#record-format) for details.
+
 ### Option B: Manual Generation
 
 If you prefer to craft the record manually:
@@ -119,6 +121,8 @@ nslookup -q=TXT _agent.my-cool-saas.com
 ---
 
 ## Part 2: For Clients (Discovering an Agent)
+
+> All SDKs parse the short wire keys (`v`, `u`, `p`, …) into descriptive field names (`proto`, `uri`, `desc`, …) so your code reads naturally.
 
 Now let's write code to find an agent. We provide libraries in several languages to make this trivial.
 


### PR DESCRIPTION
## Summary

- **Key legend** (after first generated record example): explains single-letter wire keys (`v`, `u`, `p`, `a`, `s`, `d`, `e`, `k`, `i`) with a link to the full spec table. Framed as a "read once" reference — the CLI and Live Generator handle it for you.
- **SDK mapping note** (top of Part 2: For Clients): clarifies that all SDKs parse short wire keys into descriptive field names (`proto`, `uri`, `desc`, …) so client code reads naturally.

## Test plan

- [ ] `pnpm build` passes
- [ ] Visit `/docs/quickstart` — key legend blockquote visible after the first code example
- [ ] Visit `/docs/quickstart` — SDK mapping note visible at top of Part 2
- [ ] Key legend link to `../specification.md#record-format` resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)