### PR TITLE
docs(discovery): codify exact-host lookup semantics

### DIFF
--- a/packages/aid-dotnet/README.md
+++ b/packages/aid-dotnet/README.md
@@ -38,7 +38,7 @@ using AidDiscovery;
 var result = await Discovery.DiscoverAsync(
   domain: "example.com",
   new DiscoveryOptions {
-    Protocol = "mcp",              // Try _agent._mcp., then _agent.mcp., then base
+    Protocol = "mcp",              // Try protocol-specific names for the same exact host, then the exact-host base
     Timeout = TimeSpan.FromSeconds(5),
     WellKnownFallback = true,       // Only on ERR_NO_RECORD / ERR_DNS_LOOKUP_FAILED
     WellKnownTimeout = TimeSpan.FromSeconds(2)
@@ -47,6 +47,8 @@ var result = await Discovery.DiscoverAsync(
 
 Console.WriteLine($"{result.Record.Proto} at {result.Record.Uri}, ttl={result.Ttl}, qname={result.QueryName}");
 ```
+
+Discovery is exact-host only. Passing `app.team.example.com` does not cause implicit fallback to `_agent.team.example.com` or `_agent.example.com`. Use DNS delegation on `_agent.app.team.example.com` if you want inheritance.
 
 ### Example: Handshake only
 

--- a/packages/aid-go/README.md
+++ b/packages/aid-go/README.md
@@ -44,7 +44,7 @@ func main() {
 
 ### `func Discover(domain string, timeout time.Duration) (AidRecord, uint32, error)`
 
-Discovers an agent by looking up the `_agent` TXT record for the given domain.
+Discovers an agent by looking up the `_agent` TXT record for the exact host you pass in. The resolver does not implicitly retry parent hosts.
 
 **Parameters:**
 
@@ -59,14 +59,14 @@ Discovers an agent by looking up the `_agent` TXT record for the given domain.
 
 ### `func DiscoverWithOptions(domain string, timeout time.Duration, opts DiscoveryOptions) (AidRecord, uint32, error)`
 
-Enhanced discovery with protocol-specific DNS lookup and `.well-known` controls.
+Enhanced discovery with protocol-specific DNS lookup and `.well-known` controls, still scoped to the exact host you passed in.
 
 ```go
 rec, ttl, err := aid.DiscoverWithOptions(
     "example.com",
     5*time.Second,
     aid.DiscoveryOptions{
-        Protocol:          "mcp",      // queries _agent._mcp.example.com then _agent.mcp.example.com, then base
+        Protocol:          "mcp",      // queries exact-host protocol names first, then exact-host base
         WellKnownFallback: true,        // only on ERR_NO_RECORD / ERR_DNS_LOOKUP_FAILED
         WellKnownTimeout:  2*time.Second,
     },

--- a/packages/aid-java/README.md
+++ b/packages/aid-java/README.md
@@ -40,7 +40,7 @@ import org.agentcommunity.aid.Discovery;
 import org.agentcommunity.aid.Discovery.DiscoveryOptions;
 
 var opts = new DiscoveryOptions();
-opts.protocol = "mcp";               // Try _agent._mcp., then _agent.mcp., then base
+opts.protocol = "mcp";               // Try protocol-specific names for the same exact host, then the exact-host base
 opts.timeout = java.time.Duration.ofSeconds(5);
 opts.wellKnownFallback = true;        // Only on ERR_NO_RECORD / ERR_DNS_LOOKUP_FAILED
 opts.wellKnownTimeout = java.time.Duration.ofSeconds(2);
@@ -48,6 +48,8 @@ opts.wellKnownTimeout = java.time.Duration.ofSeconds(2);
 var result = Discovery.discover("example.com", opts);
 System.out.println(result.record.proto + " at " + result.record.uri + ", ttl=" + result.ttl + ", name=" + result.queryName);
 ```
+
+Discovery is exact-host only. Passing `app.team.example.com` does not cause implicit fallback to `_agent.team.example.com` or `_agent.example.com`. Use DNS delegation on `_agent.app.team.example.com` if you want inheritance.
 
 ## Usage
 

--- a/packages/aid-py/README.md
+++ b/packages/aid-py/README.md
@@ -35,12 +35,12 @@ except AidError as e:
 
 ### `discover(domain: str, *, protocol: str | None = None, timeout: float = 5.0, well_known_fallback: bool = True, well_known_timeout: float = 2.0) -> (dict, int)`
 
-Discovers an agent by looking up the `_agent` TXT record for the given domain.
+Discovers an agent by looking up the `_agent` TXT record for the exact host you pass in. The resolver does not implicitly retry parent hosts.
 
 **Parameters:**
 
 - `domain` (str): The domain name to discover
-- `protocol` (str, optional): Try protocol-specific subdomain first (e.g., `mcp`)
+- `protocol` (str, optional): Try protocol-specific subdomain names for the same exact host first (e.g., `mcp`)
 - `timeout` (float): DNS timeout in seconds (default 5.0)
 - `well_known_fallback` (bool): If true, falls back to `https://<domain>/.well-known/agent` on `ERR_NO_RECORD` or `ERR_DNS_LOOKUP_FAILED` (default True)
 - `well_known_timeout` (float): Timeout for the `.well-known` HTTP fetch (default 2.0)

--- a/packages/aid-rs/README.md
+++ b/packages/aid-rs/README.md
@@ -67,6 +67,8 @@ async fn main() -> Result<(), aid_rs::AidError> {
 }
 ```
 
+Discovery stays on the exact host you pass in. If you call `discover_with_options("app.team.example.com", ...)`, the client does not implicitly retry `_agent.team.example.com` or `_agent.example.com`.
+
 ### Parse TXT records
 
 ```rust

--- a/packages/aid/README.md
+++ b/packages/aid/README.md
@@ -56,7 +56,7 @@ console.log('Agent:', record.proto, record.uri);
 
 - `discover(domain: string, options?)` → `{ record, ttl, queryName }`
   - Node uses DNS; Browser uses DNS-over-HTTPS.
-  - Canonical query is `_agent.<domain>`. When a specific protocol is requested, clients may query `_agent._<proto>.<domain>` as an optimization.
+  - Canonical query is `_agent.<exact-host>`. Clients do not implicitly walk to parent hosts. When a specific protocol is requested, clients may query `_agent._<proto>.<exact-host>` as an optimization.
 - `parse(txt: string)` → validated AID record
 - `AidError` – error class exposing `code` (numeric) and `errorCode` (symbol)
 - Constants and types exported from `@agentcommunity/aid`

--- a/packages/docs/Reference/discovery_api.md
+++ b/packages/docs/Reference/discovery_api.md
@@ -11,12 +11,14 @@ Cross-language parity for AID `discover()` wrappers with consistent security and
 ## Common behaviors
 
 - IDNA: Normalize domains to A-label (Punycode) before DNS.
-- DNS-first: Query `_agent.<domain>`. When `protocol` is specified, try `_agent._<proto>.<domain>` then `_agent.<proto>.<domain>` before base.
+- Exact-host only: build DNS and `.well-known` lookups from the exact host the caller supplied after IDNA normalization. Do not implicitly walk to parent hosts.
+- DNS-first: Query `_agent.<domain>`. When `protocol` is specified, try protocol-specific names for that same exact host before base.
 - TXT parsing: Enforce v1.2 record rules (aliases, schemes, metadata constraints).
 - Multiple TXT answers: exactly one valid AID record at a queried DNS name succeeds; `2+` valid records fail as ambiguity instead of using resolver order.
 - PKA: When `pka`/`kid` present, perform Ed25519 HTTP Message Signatures handshake with exact covered fields set.
 - Well-known fallback: Only on `ERR_NO_RECORD` or `ERR_DNS_LOOKUP_FAILED`. HTTPS JSON, ≤64KB, ~2s timeout, no redirects. Successful fallback uses `TTL=300`.
 - Redirect policy: Do not auto-follow redirects for handshake or well-known.
+- Delegation: if operators want inheritance, they should delegate the exact `_agent.<child-host>` label in DNS, for example with `CNAME`.
 
 ## Options by language
 

--- a/packages/docs/export-manifest.json
+++ b/packages/docs/export-manifest.json
@@ -64,8 +64,8 @@
     },
     {
       "path": "Reference/discovery_api.md",
-      "bytes": 3071,
-      "sha256": "4dbea16d709894bc7a1f83d1595e84579659854f016999cea82f7399a53adc4f"
+      "bytes": 3361,
+      "sha256": "eb68935604308108f5a28d0b242940445ae96e01308a8b5b33a29046efd06408"
     },
     {
       "path": "Reference/identity_pka.md",
@@ -99,8 +99,8 @@
     },
     {
       "path": "specification.md",
-      "bytes": 17160,
-      "sha256": "15c8cc982b39341cfdbe3fa7e7c99aeb565e9272754ca0c878ba16d5ab6509db"
+      "bytes": 18475,
+      "sha256": "0faf2e885d8ba6b3308ceb177b4c32fd292a4f10a4b2652aaf21591d42362681"
     },
     {
       "path": "Tooling/aid_doctor.md",
@@ -138,5 +138,5 @@
       "sha256": "985c0214d91997524c53b078da3a8b87599709ee71c1d39b0cfa96764bcbd117"
     }
   ],
-  "aggregateSha256": "6be9d26b6a0f6c22d8f21dd17dc0bea76048d9cb8be328c034f0d2d6368fad74"
+  "aggregateSha256": "e70e412dc34ffa88ff29fdc36478b054466f686f1421ed84eba870775cdb55fc"
 }

--- a/packages/docs/export-manifest.sha256
+++ b/packages/docs/export-manifest.sha256
@@ -1,1 +1,1 @@
-6be9d26b6a0f6c22d8f21dd17dc0bea76048d9cb8be328c034f0d2d6368fad74  export-manifest.json
+e70e412dc34ffa88ff29fdc36478b054466f686f1421ed84eba870775cdb55fc  export-manifest.json


### PR DESCRIPTION
Closes #92

## Summary
- codify exact-host-only discovery and explicit DNS delegation in the spec
- update SDK-facing docs to state that clients do not walk parent hosts implicitly
- add regression tests covering exact-host behavior in TS, Python, and Go

## Validation
- pnpm --dir packages/aid exec vitest run src/client.protocol.test.ts src/client.browser.test.ts
- python3 -m pytest packages/aid-py/tests/test_discover.py
- cd packages/aid-go && go test ./...
- pnpm docs:verify