### PR TITLE
feat(security): add enterprise discovery policy presets

### DIFF
--- a/.changeset/enterprise-security-profile.md
+++ b/.changeset/enterprise-security-profile.md
@@ -1,0 +1,7 @@
+---
+"@agentcommunity/aid": patch
+"@agentcommunity/aid-engine": patch
+"@agentcommunity/aid-doctor": patch
+---
+
+Add enterprise discovery policy controls with `balanced` and `strict` presets, low-level DNSSEC/PKA/downgrade/well-known options, and updated docs for the new security model.

--- a/packages/aid-doctor/README.md
+++ b/packages/aid-doctor/README.md
@@ -42,6 +42,11 @@ aid-doctor json example.com
 - `--timeout <ms>`: DNS query timeout (default: 5000)
 - `--no-fallback`: disable `.well-known` fallback on DNS miss
 - `--fallback-timeout <ms>`: HTTP timeout for `.well-known` (default: 2000)
+- `--security-mode <mode>`: enterprise preset (`balanced` or `strict`)
+- `--dnssec <policy>`: DNSSEC policy (`off`, `prefer`, `require`)
+- `--pka-policy <policy>`: PKA policy (`if-present`, `require`)
+- `--downgrade-policy <policy>`: downgrade policy (`off`, `warn`, `fail`)
+- `--well-known-policy <policy>`: `.well-known` policy (`auto`, `disable`)
 - `--show-details`: include fallback usage and PKA status in output
 - `--code` (check): exit with specific error code on failure
 
@@ -75,9 +80,13 @@ aid-doctor json example.com > result.json
 # Show PKA/fallback details (v1.1)
 aid-doctor check example.com --show-details
 
+# Enterprise preset with downgrade cache
+aid-doctor check example.com --security-mode strict --check-downgrade
+
 # Local testing with a mock HTTP server (insecure well-known)
 # (Use only for local dev)
 AID_ALLOW_INSECURE_WELL_KNOWN=1 aid-doctor check localhost:19081 --show-details --fallback-timeout 2000
+```
 
 ### PKA handshake expectations
 
@@ -90,7 +99,6 @@ AID_ALLOW_INSECURE_WELL_KNOWN=1 aid-doctor check localhost:19081 --show-details 
 ### Loopback HTTP (dev‑only)
 
 When `AID_ALLOW_INSECURE_WELL_KNOWN=1` is set and the domain is loopback (`localhost`/`127.0.0.1`/`::1`), the doctor permits `http://` in the `.well-known` path for local testing. All other validations, including PKA, still run. TXT discovery always enforces `https://` for remote agents.
-```
 
 ## License
 

--- a/packages/aid-doctor/src/cli.test.ts
+++ b/packages/aid-doctor/src/cli.test.ts
@@ -51,6 +51,9 @@ describe('AID Doctor CLI', () => {
       expect(cliContent).toContain('.description(');
       expect(cliContent).toContain('.version(');
       expect(cliContent).toContain('.command(');
+      expect(cliContent).toContain('--security-mode <mode>');
+      expect(cliContent).toContain('--dnssec <policy>');
+      expect(cliContent).toContain('--pka-policy <policy>');
     });
   });
 

--- a/packages/aid-doctor/src/cli.ts
+++ b/packages/aid-doctor/src/cli.ts
@@ -92,6 +92,11 @@ program
   .option('-t, --timeout <ms>', 'DNS query timeout in milliseconds', '5000')
   .option('--no-fallback', 'Disable .well-known fallback on DNS miss', false)
   .option('--fallback-timeout <ms>', 'Timeout for .well-known fetch (ms)', '2000')
+  .option('--security-mode <mode>', 'Security preset: balanced | strict')
+  .option('--dnssec <policy>', 'DNSSEC policy: off | prefer | require')
+  .option('--pka-policy <policy>', 'PKA policy: if-present | require')
+  .option('--downgrade-policy <policy>', 'Downgrade policy: off | warn | fail')
+  .option('--well-known-policy <policy>', 'Well-known policy: auto | disable')
   .option('--show-details', 'Show TLS/DNSSEC/PKA short details', false)
   .option('--dump-well-known [path]', 'On fallback failure, print or save body snippet', false)
   .option('--check-downgrade', 'Consult cache and warn when pka has been removed or changed', false)
@@ -107,6 +112,11 @@ program
         timeout: string;
         noFallback?: boolean;
         fallbackTimeout?: string;
+        securityMode?: 'balanced' | 'strict';
+        dnssec?: 'off' | 'prefer' | 'require';
+        pkaPolicy?: 'if-present' | 'require';
+        downgradePolicy?: 'off' | 'warn' | 'fail';
+        wellKnownPolicy?: 'auto' | 'disable';
         showDetails?: boolean;
         dumpWellKnown?: string | boolean;
         checkDowngrade?: boolean;
@@ -131,6 +141,14 @@ program
           timeoutMs: Number.parseInt(options.timeout),
           allowFallback: !options.noFallback,
           wellKnownTimeoutMs: Number.parseInt(options.fallbackTimeout || '2000'),
+          securityMode: options.securityMode,
+          dnssecPolicy: options.dnssec,
+          pkaPolicy: options.pkaPolicy,
+          downgradePolicy: options.downgradePolicy,
+          wellKnownPolicy: options.wellKnownPolicy,
+          previousSecurity: previousCacheEntry
+            ? { pka: previousCacheEntry.pka, kid: previousCacheEntry.kid }
+            : undefined,
           showDetails: options.showDetails,
           probeProtoSubdomain: options.probeProtoSubdomain,
           probeProtoEvenIfBase: options.probeProtoEvenIfBase,
@@ -172,6 +190,11 @@ program
   .option('-t, --timeout <ms>', 'DNS query timeout in milliseconds', '5000')
   .option('--no-fallback', 'Disable .well-known fallback on DNS miss', false)
   .option('--fallback-timeout <ms>', 'Timeout for .well-known fetch (ms)', '2000')
+  .option('--security-mode <mode>', 'Security preset: balanced | strict')
+  .option('--dnssec <policy>', 'DNSSEC policy: off | prefer | require')
+  .option('--pka-policy <policy>', 'PKA policy: if-present | require')
+  .option('--downgrade-policy <policy>', 'Downgrade policy: off | warn | fail')
+  .option('--well-known-policy <policy>', 'Well-known policy: auto | disable')
   .option('--show-details', 'Show TLS/DNSSEC/PKA short details', false)
   .option('--dump-well-known [path]', 'On fallback failure, print or save body snippet', false)
   .option('--check-downgrade', 'Consult cache and warn when pka has been removed or changed', false)
@@ -185,6 +208,11 @@ program
         timeout: string;
         noFallback?: boolean;
         fallbackTimeout?: string;
+        securityMode?: 'balanced' | 'strict';
+        dnssec?: 'off' | 'prefer' | 'require';
+        pkaPolicy?: 'if-present' | 'require';
+        downgradePolicy?: 'off' | 'warn' | 'fail';
+        wellKnownPolicy?: 'auto' | 'disable';
         showDetails?: boolean;
         dumpWellKnown?: string | boolean;
         checkDowngrade?: boolean;
@@ -201,6 +229,14 @@ program
           timeoutMs: Number.parseInt(options.timeout),
           allowFallback: !options.noFallback,
           wellKnownTimeoutMs: Number.parseInt(options.fallbackTimeout || '2000'),
+          securityMode: options.securityMode,
+          dnssecPolicy: options.dnssec,
+          pkaPolicy: options.pkaPolicy,
+          downgradePolicy: options.downgradePolicy,
+          wellKnownPolicy: options.wellKnownPolicy,
+          previousSecurity: previousCacheEntry
+            ? { pka: previousCacheEntry.pka, kid: previousCacheEntry.kid }
+            : undefined,
           showDetails: options.showDetails || false,
           probeProtoSubdomain: false, // JSON command doesn't support proto probing for now
           probeProtoEvenIfBase: false,

--- a/packages/aid-engine/src/checker.ts
+++ b/packages/aid-engine/src/checker.ts
@@ -62,6 +62,12 @@ export async function runCheck(domain: string, opts: CheckOptions): Promise<Doct
       timeoutMs: opts.timeoutMs,
       allowFallback: opts.allowFallback,
       wellKnownTimeoutMs: opts.wellKnownTimeoutMs,
+      ...(opts.securityMode ? { securityMode: opts.securityMode } : {}),
+      ...(opts.dnssecPolicy ? { dnssecPolicy: opts.dnssecPolicy } : {}),
+      ...(opts.pkaPolicy ? { pkaPolicy: opts.pkaPolicy } : {}),
+      ...(opts.downgradePolicy ? { downgradePolicy: opts.downgradePolicy } : {}),
+      ...(opts.wellKnownPolicy ? { wellKnownPolicy: opts.wellKnownPolicy } : {}),
+      ...(opts.previousSecurity ? { previousSecurity: opts.previousSecurity } : {}),
     });
     // This is the success path now
     if (!dnsRes.ok) {
@@ -98,6 +104,12 @@ export async function runCheck(domain: string, opts: CheckOptions): Promise<Doct
     const record = value.record;
     report.record.parsed = record;
     report.record.valid = true;
+    for (const warning of value.security.warnings) {
+      report.record.warnings.push({
+        code: warning.code,
+        message: warning.message,
+      });
+    }
     report.record.raw = (() => {
       // For DNS, we don't receive raw concatenated string from SDK; synthesize minimal
       // to enable byte warnings based on a canonicalized render.

--- a/packages/aid-engine/src/types.ts
+++ b/packages/aid-engine/src/types.ts
@@ -1,4 +1,12 @@
-import type { AidRecord } from '@agentcommunity/aid';
+import type {
+  AidRecord,
+  DnssecPolicy,
+  DowngradePolicy,
+  PkaPolicy,
+  PreviousSecurityState,
+  SecurityMode,
+  WellKnownPolicy,
+} from '@agentcommunity/aid';
 
 export interface CacheEntry {
   lastSeen: string;
@@ -101,6 +109,12 @@ export interface CheckOptions {
   timeoutMs: number;
   allowFallback: boolean;
   wellKnownTimeoutMs: number;
+  securityMode?: SecurityMode;
+  dnssecPolicy?: DnssecPolicy;
+  pkaPolicy?: PkaPolicy;
+  downgradePolicy?: DowngradePolicy;
+  wellKnownPolicy?: WellKnownPolicy;
+  previousSecurity?: PreviousSecurityState;
   showDetails?: boolean;
   dumpWellKnownPath?: string | null;
   checkDowngrade?: boolean;

--- a/packages/aid/README.md
+++ b/packages/aid/README.md
@@ -57,9 +57,24 @@ console.log('Agent:', record.proto, record.uri);
 - `discover(domain: string, options?)` → `{ record, ttl, queryName }`
   - Node uses DNS; Browser uses DNS-over-HTTPS.
   - Canonical query is `_agent.<exact-host>`. Clients do not implicitly walk to parent hosts. When a specific protocol is requested, clients may query `_agent._<proto>.<exact-host>` as an optimization.
+  - Enterprise controls: `securityMode: 'balanced' | 'strict'` plus low-level policy knobs for DNSSEC, PKA, downgrade handling, and `.well-known`.
 - `parse(txt: string)` → validated AID record
 - `AidError` – error class exposing `code` (numeric) and `errorCode` (symbol)
 - Constants and types exported from `@agentcommunity/aid`
+
+### Example: enterprise policy preset
+
+```ts
+import { discover } from '@agentcommunity/aid';
+
+const result = await discover('example.com', {
+  securityMode: 'balanced',
+  previousSecurity: { pka: 'zOldKey', kid: 'g1' },
+});
+
+console.log(result.security.mode);
+console.log(result.security.warnings);
+```
 
 ## v1.2 Notes (PKA + .well-known)
 

--- a/packages/aid/src/client.security-policy.test.ts
+++ b/packages/aid/src/client.security-policy.test.ts
@@ -1,0 +1,190 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { discover } from './index.js';
+import * as browser from './browser.js';
+
+vi.mock('dns-query', () => ({
+  query: vi.fn(),
+}));
+
+vi.mock('./pka.js', () => ({
+  performPKAHandshake: vi.fn(async () => {}),
+}));
+
+describe('Discovery security policy', () => {
+  const g = globalThis as { fetch?: typeof fetch };
+  let originalFetch: typeof fetch | undefined;
+  let originalWarn: typeof console.warn;
+
+  beforeEach(() => {
+    originalFetch = g.fetch;
+    originalWarn = console.warn;
+    console.warn = vi.fn();
+  });
+
+  afterEach(() => {
+    g.fetch = originalFetch;
+    console.warn = originalWarn;
+    vi.restoreAllMocks();
+  });
+
+  it('node strict mode requires PKA', async () => {
+    const { query } = await import('dns-query');
+    (query as any).mockResolvedValue({
+      rcode: 'NOERROR',
+      answers: [
+        {
+          type: 'TXT',
+          name: '_agent.example.com',
+          data: 'v=aid1;u=https://api.example.com/mcp;p=mcp',
+          ttl: 300,
+        },
+      ],
+    });
+
+    await expect(discover('example.com', { securityMode: 'strict' })).rejects.toMatchObject({
+      errorCode: 'ERR_SECURITY',
+    });
+  });
+
+  it('node strict mode requires DNSSEC validation', async () => {
+    const { query } = await import('dns-query');
+    (query as any).mockResolvedValue({
+      rcode: 'NOERROR',
+      answers: [
+        {
+          type: 'TXT',
+          name: '_agent.example.com',
+          data: 'v=aid1;u=https://api.example.com/mcp;p=mcp;k=zBase58EncodedKey;i=g1',
+          ttl: 300,
+        },
+      ],
+    });
+    g.fetch = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      headers: { get: () => 'application/dns-json' },
+      text: async () => JSON.stringify({ Status: 0, AD: false }),
+    })) as typeof fetch;
+
+    await expect(discover('example.com', { securityMode: 'strict' })).rejects.toMatchObject({
+      errorCode: 'ERR_SECURITY',
+    });
+  });
+
+  it('node balanced mode warns when DNSSEC is preferred but unavailable', async () => {
+    const { query } = await import('dns-query');
+    (query as any).mockResolvedValue({
+      rcode: 'NOERROR',
+      answers: [
+        {
+          type: 'TXT',
+          name: '_agent.example.com',
+          data: 'v=aid1;u=https://api.example.com/mcp;p=mcp',
+          ttl: 300,
+        },
+      ],
+    });
+    g.fetch = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      headers: { get: () => 'application/dns-json' },
+      text: async () => JSON.stringify({ Status: 0, AD: false }),
+    })) as typeof fetch;
+
+    const result = await discover('example.com', { securityMode: 'balanced' });
+    expect(result.security.warnings.map((warning) => warning.code)).toContain('DNSSEC_PREFERRED');
+  });
+
+  it('node can fail on downgrade when previous security state is supplied', async () => {
+    const { query } = await import('dns-query');
+    (query as any).mockResolvedValue({
+      rcode: 'NOERROR',
+      answers: [
+        {
+          type: 'TXT',
+          name: '_agent.example.com',
+          data: 'v=aid1;u=https://api.example.com/mcp;p=mcp',
+          ttl: 300,
+        },
+      ],
+    });
+
+    await expect(
+      discover('example.com', {
+        dnssecPolicy: 'off',
+        downgradePolicy: 'fail',
+        previousSecurity: { pka: 'zOldKey', kid: 'g1' },
+      }),
+    ).rejects.toMatchObject({
+      errorCode: 'ERR_SECURITY',
+    });
+  });
+
+  it('node strict mode disables well-known fallback', async () => {
+    const { query } = await import('dns-query');
+    (query as any).mockImplementation(async () => {
+      const error: any = new Error('ENOTFOUND');
+      error.code = 'ENOTFOUND';
+      throw error;
+    });
+    g.fetch = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      headers: { get: () => 'application/json' },
+      text: async () => JSON.stringify({ v: 'aid1', u: 'https://api.example.com/mcp', p: 'mcp' }),
+    })) as typeof fetch;
+
+    await expect(discover('example.com', { securityMode: 'strict' })).rejects.toMatchObject({
+      errorCode: 'ERR_NO_RECORD',
+    });
+  });
+
+  it('browser strict mode requires DNSSEC validation', async () => {
+    g.fetch = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        Status: 0,
+        AD: false,
+        Answer: [
+          {
+            name: '_agent.example.com',
+            type: 16,
+            TTL: 300,
+            data: '"v=aid1;u=https://api.example.com/mcp;p=mcp;k=zBase58EncodedKey;i=g1"',
+          },
+        ],
+      }),
+    })) as typeof fetch;
+
+    await expect(browser.discover('example.com', { securityMode: 'strict' })).rejects.toMatchObject(
+      {
+        errorCode: 'ERR_SECURITY',
+      },
+    );
+  });
+
+  it('browser strict mode disables well-known fallback', async () => {
+    g.fetch = vi.fn(async (url: string | URL) => {
+      if (url.toString().includes('cloudflare-dns.com')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ Status: 2 }),
+        } as Response;
+      }
+      return {
+        ok: true,
+        status: 200,
+        headers: { get: () => 'application/json' },
+        text: async () => JSON.stringify({ v: 'aid1', u: 'https://api.example.com/mcp', p: 'mcp' }),
+      } as Response;
+    }) as typeof fetch;
+
+    await expect(browser.discover('example.com', { securityMode: 'strict' })).rejects.toMatchObject(
+      {
+        errorCode: 'ERR_NO_RECORD',
+      },
+    );
+  });
+});

--- a/packages/aid/src/discovery-security.ts
+++ b/packages/aid/src/discovery-security.ts
@@ -1,0 +1,270 @@
+import { type AidRecord } from './constants.js';
+import { AidError } from './parser.js';
+
+export type SecurityMode = 'balanced' | 'strict';
+export type DnssecPolicy = 'off' | 'prefer' | 'require';
+export type PkaPolicy = 'if-present' | 'require';
+export type DowngradePolicy = 'off' | 'warn' | 'fail';
+export type WellKnownPolicy = 'auto' | 'disable';
+
+export interface PreviousSecurityState {
+  pka?: string | null;
+  kid?: string | null;
+}
+
+export interface SecurityPolicyOptions {
+  securityMode?: SecurityMode;
+  dnssecPolicy?: DnssecPolicy;
+  pkaPolicy?: PkaPolicy;
+  downgradePolicy?: DowngradePolicy;
+  wellKnownPolicy?: WellKnownPolicy;
+  previousSecurity?: PreviousSecurityState;
+}
+
+export interface DiscoverySecurityWarning {
+  code: 'DNSSEC_PREFERRED' | 'DOWNGRADE_DETECTED' | 'WELL_KNOWN_PREFERRED';
+  message: string;
+}
+
+export interface DiscoverySecurity {
+  mode: 'default' | SecurityMode | 'custom';
+  dnssec: {
+    policy: DnssecPolicy;
+    checked: boolean;
+    validated: boolean | null;
+  };
+  pka: {
+    policy: PkaPolicy;
+    present: boolean;
+  };
+  wellKnown: {
+    policy: WellKnownPolicy;
+    used: boolean;
+  };
+  downgrade: {
+    policy: DowngradePolicy;
+    checked: boolean;
+    detected: boolean;
+    reason: string | null;
+  };
+  warnings: DiscoverySecurityWarning[];
+}
+
+export interface ResolvedSecurityPolicy {
+  mode: DiscoverySecurity['mode'];
+  dnssecPolicy: DnssecPolicy;
+  pkaPolicy: PkaPolicy;
+  downgradePolicy: DowngradePolicy;
+  wellKnownPolicy: WellKnownPolicy;
+  previousSecurity?: PreviousSecurityState;
+}
+
+export function resolveSecurityPolicy(options: {
+  securityMode?: SecurityMode;
+  dnssecPolicy?: DnssecPolicy;
+  pkaPolicy?: PkaPolicy;
+  downgradePolicy?: DowngradePolicy;
+  wellKnownPolicy?: WellKnownPolicy;
+  previousSecurity?: PreviousSecurityState;
+  wellKnownFallback?: boolean;
+}): ResolvedSecurityPolicy {
+  const defaultPolicy: ResolvedSecurityPolicy = {
+    mode: 'default',
+    dnssecPolicy: 'off',
+    pkaPolicy: 'if-present',
+    downgradePolicy: 'off',
+    wellKnownPolicy: options.wellKnownFallback === false ? 'disable' : 'auto',
+    ...(options.previousSecurity ? { previousSecurity: options.previousSecurity } : {}),
+  };
+
+  if (!options.securityMode) {
+    return {
+      ...defaultPolicy,
+      dnssecPolicy: options.dnssecPolicy ?? defaultPolicy.dnssecPolicy,
+      pkaPolicy: options.pkaPolicy ?? defaultPolicy.pkaPolicy,
+      downgradePolicy: options.downgradePolicy ?? defaultPolicy.downgradePolicy,
+      wellKnownPolicy: options.wellKnownPolicy ?? defaultPolicy.wellKnownPolicy,
+    };
+  }
+
+  const preset =
+    options.securityMode === 'strict'
+      ? {
+          mode: 'strict' as const,
+          dnssecPolicy: 'require' as const,
+          pkaPolicy: 'require' as const,
+          downgradePolicy: 'fail' as const,
+          wellKnownPolicy: 'disable' as const,
+        }
+      : {
+          mode: 'balanced' as const,
+          dnssecPolicy: 'prefer' as const,
+          pkaPolicy: 'if-present' as const,
+          downgradePolicy: 'warn' as const,
+          wellKnownPolicy: 'auto' as const,
+        };
+
+  const overrideUsed =
+    options.dnssecPolicy !== undefined ||
+    options.pkaPolicy !== undefined ||
+    options.downgradePolicy !== undefined ||
+    options.wellKnownPolicy !== undefined ||
+    options.wellKnownFallback === false;
+
+  return {
+    mode: overrideUsed ? 'custom' : preset.mode,
+    dnssecPolicy: options.dnssecPolicy ?? preset.dnssecPolicy,
+    pkaPolicy: options.pkaPolicy ?? preset.pkaPolicy,
+    downgradePolicy: options.downgradePolicy ?? preset.downgradePolicy,
+    wellKnownPolicy:
+      options.wellKnownPolicy ??
+      (options.wellKnownFallback === false ? 'disable' : preset.wellKnownPolicy),
+    ...(options.previousSecurity ? { previousSecurity: options.previousSecurity } : {}),
+  };
+}
+
+export function createDiscoverySecurity(
+  policy: ResolvedSecurityPolicy,
+  usedWellKnown: boolean,
+): DiscoverySecurity {
+  return {
+    mode: policy.mode,
+    dnssec: {
+      policy: policy.dnssecPolicy,
+      checked: false,
+      validated: null,
+    },
+    pka: {
+      policy: policy.pkaPolicy,
+      present: false,
+    },
+    wellKnown: {
+      policy: policy.wellKnownPolicy,
+      used: usedWellKnown,
+    },
+    downgrade: {
+      policy: policy.downgradePolicy,
+      checked: policy.downgradePolicy !== 'off' && Boolean(policy.previousSecurity),
+      detected: false,
+      reason: null,
+    },
+    warnings: [],
+  };
+}
+
+export function addSecurityWarning(
+  security: DiscoverySecurity,
+  warning: DiscoverySecurityWarning,
+): void {
+  security.warnings.push(warning);
+  console.warn(`[AID] WARNING: ${warning.message}`);
+}
+
+export function enforcePkaPolicy(
+  record: AidRecord,
+  queryName: string,
+  security: DiscoverySecurity,
+): void {
+  security.pka.present = Boolean(record.pka);
+  if (security.pka.policy === 'require' && !record.pka) {
+    throw new AidError(
+      'ERR_SECURITY',
+      `PKA is required by security policy for ${queryName}; publish pka and kid before using this endpoint`,
+    );
+  }
+}
+
+export function enforceDowngradePolicy(
+  record: AidRecord,
+  queryName: string,
+  policy: ResolvedSecurityPolicy,
+  security: DiscoverySecurity,
+): void {
+  if (policy.downgradePolicy === 'off' || !policy.previousSecurity) {
+    return;
+  }
+
+  const previousPka = policy.previousSecurity.pka ?? null;
+  const previousKid = policy.previousSecurity.kid ?? null;
+  const currentPka = record.pka ?? null;
+  const currentKid = record.kid ?? null;
+
+  let reason: string | null = null;
+  if (previousPka && !currentPka) {
+    reason = 'previously present pka was removed';
+  } else if (previousPka && currentPka && previousPka !== currentPka) {
+    reason = 'pka value changed';
+  } else if (previousKid && currentKid && previousKid !== currentKid) {
+    reason = 'kid value changed';
+  }
+
+  if (!reason) {
+    return;
+  }
+
+  security.downgrade.detected = true;
+  security.downgrade.reason = reason;
+
+  const message = `Security downgrade detected for ${queryName}: ${reason}`;
+  if (policy.downgradePolicy === 'fail') {
+    throw new AidError('ERR_SECURITY', message);
+  }
+  addSecurityWarning(security, {
+    code: 'DOWNGRADE_DETECTED',
+    message,
+  });
+}
+
+export function enforceDnssecPolicy(
+  security: DiscoverySecurity,
+  queryName: string,
+  validated: boolean | null,
+): void {
+  security.dnssec.checked = validated !== null;
+  security.dnssec.validated = validated;
+
+  if (security.dnssec.policy === 'off') {
+    return;
+  }
+
+  if (validated) {
+    return;
+  }
+
+  const message =
+    validated === null
+      ? `DNSSEC could not be evaluated for ${queryName}`
+      : `DNSSEC validation was not available for ${queryName}`;
+
+  if (security.dnssec.policy === 'require') {
+    throw new AidError('ERR_SECURITY', message);
+  }
+
+  addSecurityWarning(security, {
+    code: 'DNSSEC_PREFERRED',
+    message,
+  });
+}
+
+export function enforceWellKnownPolicy(security: DiscoverySecurity, queryName: string): void {
+  if (security.wellKnown.policy === 'disable') {
+    throw new AidError(
+      'ERR_SECURITY',
+      `Well-known fallback is disabled by security policy for ${queryName}`,
+    );
+  }
+
+  if (security.dnssec.policy === 'require') {
+    throw new AidError(
+      'ERR_SECURITY',
+      `DNSSEC is required by security policy for ${queryName}; .well-known fallback cannot satisfy that requirement`,
+    );
+  }
+
+  if (security.dnssec.policy === 'prefer') {
+    addSecurityWarning(security, {
+      code: 'WELL_KNOWN_PREFERRED',
+      message: `Well-known fallback was used for ${queryName}; DNSSEC preference could not be satisfied on this path`,
+    });
+  }
+}

--- a/packages/aid/src/index.ts
+++ b/packages/aid/src/index.ts
@@ -34,6 +34,17 @@ export {
 // Security helpers
 export { enforceRedirectPolicy } from './security.js';
 export { performPKAHandshake } from './pka.js';
+export type {
+  SecurityMode,
+  DnssecPolicy,
+  PkaPolicy,
+  DowngradePolicy,
+  WellKnownPolicy,
+  PreviousSecurityState,
+  DiscoverySecurity,
+  DiscoverySecurityWarning,
+  SecurityPolicyOptions,
+} from './discovery-security.js';
 
 // Re-export client functions and types
 export { type DiscoveryResult, type DiscoveryOptions, discover } from './client.js';

--- a/packages/docs/Reference/discovery_api.md
+++ b/packages/docs/Reference/discovery_api.md
@@ -22,7 +22,8 @@ Cross-language parity for AID `discover()` wrappers with consistent security and
 
 ## Options by language
 
-- TypeScript/Node: `{ protocol?: string; timeout?: number; wellKnownFallback?: boolean; wellKnownTimeoutMs?: number }`
+- TypeScript/Node: `{ protocol?: string; timeout?: number; wellKnownFallback?: boolean; wellKnownTimeoutMs?: number; securityMode?: 'balanced' | 'strict'; dnssecPolicy?: 'off' | 'prefer' | 'require'; pkaPolicy?: 'if-present' | 'require'; downgradePolicy?: 'off' | 'warn' | 'fail'; wellKnownPolicy?: 'auto' | 'disable'; previousSecurity?: { pka?: string | null; kid?: string | null } }`
+- TypeScript/Browser: same policy fields as Node, plus `dohProvider?: string`
 - Python: `discover(domain, *, protocol=None, timeout=5.0, well_known_fallback=True, well_known_timeout=2.0)`
   - Accepts camelCase aliases `wellKnownFallback` and `wellKnownTimeoutMs` (deprecated with warnings)
 - Go: `DiscoverWithOptions(domain string, timeout time.Duration, opts DiscoveryOptions)`
@@ -47,6 +48,8 @@ Cross-language parity for AID `discover()` wrappers with consistent security and
 
 - Loopback relax: allowed only for `.well-known` fallback and only on loopback hosts; env/flag gated per language (never for TXT).
 - Rust PKA is behind the `handshake` feature; enable it to run handshake verification.
+- `balanced` and `strict` are the normative enterprise presets for v1.2.x.
+- The reference TypeScript SDK and `aid-doctor` CLI currently expose the full preset/knob surface. Other SDKs should map to the same policy model as they catch up.
 - Test your implementation using the [aid-doctor CLI](../Tooling/aid_doctor.md) tool for real-world validation.
 
 ## See also

--- a/packages/docs/export-manifest.json
+++ b/packages/docs/export-manifest.json
@@ -64,8 +64,8 @@
     },
     {
       "path": "Reference/discovery_api.md",
-      "bytes": 3361,
-      "sha256": "eb68935604308108f5a28d0b242940445ae96e01308a8b5b33a29046efd06408"
+      "bytes": 3945,
+      "sha256": "1a16d952228e4e8a0b989e267be6e5a7a3cff4605abb86d1d1e638943f2d2821"
     },
     {
       "path": "Reference/identity_pka.md",
@@ -99,8 +99,8 @@
     },
     {
       "path": "specification.md",
-      "bytes": 18475,
-      "sha256": "0faf2e885d8ba6b3308ceb177b4c32fd292a4f10a4b2652aaf21591d42362681"
+      "bytes": 19968,
+      "sha256": "c1d154b2498a1b173124539fd39fe31e056c90a97ed2037a2b36793b1d527763"
     },
     {
       "path": "Tooling/aid_doctor.md",
@@ -138,5 +138,5 @@
       "sha256": "985c0214d91997524c53b078da3a8b87599709ee71c1d39b0cfa96764bcbd117"
     }
   ],
-  "aggregateSha256": "e70e412dc34ffa88ff29fdc36478b054466f686f1421ed84eba870775cdb55fc"
+  "aggregateSha256": "bb6b04ec8c3de678f88dd17bfab9f025c7a2dc48d54fe7a2825289f9831a6289"
 }

--- a/packages/docs/export-manifest.sha256
+++ b/packages/docs/export-manifest.sha256
@@ -1,1 +1,1 @@
-e70e412dc34ffa88ff29fdc36478b054466f686f1421ed84eba870775cdb55fc  export-manifest.json
+bb6b04ec8c3de678f88dd17bfab9f025c7a2dc48d54fe7a2825289f9831a6289  export-manifest.json

--- a/packages/docs/specification.md
+++ b/packages/docs/specification.md
@@ -180,6 +180,41 @@ _agent._a2a.example.com. 300 IN TXT "v=aid1;p=a2a;uri=..."
   a. terminate with `ERR_SECURITY`, or  
   b. require explicit user confirmation before proceeding.
 
+### **3.1 Enterprise Policy Modes**
+
+Clients that expose enterprise controls **SHOULD** provide a preset mode surface and **MAY** also expose the underlying policy knobs directly.
+
+The normative preset names for v1.2.x are:
+
+- `balanced`
+  - `pka`: `if-present`
+  - `dnssec`: `prefer`
+  - `well-known`: `auto`
+  - `downgrade`: `warn`
+- `strict`
+  - `pka`: `require`
+  - `dnssec`: `require`
+  - `well-known`: `disable`
+  - `downgrade`: `fail`
+
+The underlying policy knobs are:
+
+- **PKA policy:** `if-present | require`
+- **DNSSEC policy:** `off | prefer | require`
+- **Well-known policy:** `auto | disable`
+- **Downgrade policy:** `off | warn | fail`
+
+Policy semantics:
+
+- **PKA `require`:** discovery **MUST** fail with `ERR_SECURITY` if the selected record does not publish `pka` and `kid`.
+- **DNSSEC `prefer`:** clients **SHOULD** continue when DNSSEC cannot be validated, but **SHOULD** surface a warning.
+- **DNSSEC `require`:** clients **MUST** fail with `ERR_SECURITY` when DNSSEC validation is unavailable or unsuccessful for the selected DNS answer.
+- **Well-known `disable`:** clients **MUST NOT** use `/.well-known/agent` fallback.
+- **Downgrade `warn`:** if a previously seen `pka` disappears or `pka`/`kid` changes, clients **SHOULD** surface a warning.
+- **Downgrade `fail`:** if a previously seen `pka` disappears or `pka`/`kid` changes, clients **MUST** fail with `ERR_SECURITY`.
+
+If discovery succeeds only through `.well-known`, that result cannot satisfy `dnssec=require`.
+
 ---
 
 ## **4. DNS and Caching**


### PR DESCRIPTION
Closes #93

## Summary
- add `balanced` and `strict` discovery security presets to the reference TypeScript SDK
- expose low-level DNSSEC, PKA, downgrade, and well-known policy controls
- wire the same policy surface into `aid-engine` and `aid-doctor`
- document the enterprise policy model in the spec and discovery API docs

## Validation
- pnpm docs:verify
- pnpm --dir packages/aid exec vitest run src/client.security-policy.test.ts src/client.fallback.test.ts src/client.protocol.test.ts src/client.browser.test.ts src/client.pka.test.ts
- pnpm --dir packages/aid-engine exec tsc --noEmit
- pnpm --dir packages/aid-doctor exec tsc --noEmit
- pnpm --dir packages/aid-doctor exec vitest run src/cli.test.ts