### PR TITLE
test(conformance): expand parity vectors and gates

### DIFF
--- a/.changeset/enterprise-conformance-vectors.md
+++ b/.changeset/enterprise-conformance-vectors.md
@@ -1,0 +1,5 @@
+---
+"@agentcommunity/aid-conformance": patch
+---
+
+Expand shared conformance coverage with more invalid parser fixtures and publish enterprise security vector fixtures for reference discovery tests.

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "dev:all": "turbo run dev --parallel",
     "build": "turbo run build",
     "test": "turbo run test",
-    "test:parity": "pnpm -C packages/aid test && (cd packages/aid-go && go test ./...) && python3 -m pip install -e \"packages/aid-py[dev,pka]\" && python3 -m pytest packages/aid-py",
+    "test:parity": "pnpm -C packages/aid-conformance test && pnpm -C packages/aid test && (cd packages/aid-go && go test ./...) && python3 -m pip install -e \"packages/aid-py[dev,pka]\" && python3 -m pytest packages/aid-py",
     "lint": "turbo run lint",
     "clean": "turbo run clean",
     "one-shot": "eslint --cache --max-warnings 0 .",

--- a/packages/aid-conformance/README.md
+++ b/packages/aid-conformance/README.md
@@ -16,7 +16,12 @@ Built by the team at [agentcommunity.org](https://agentcommunity.org).
 - **Docs**: [docs.agentcommunity.org/aid](https://docs.agentcommunity.org/aid)
 - **GitHub**: [github.com/agent-community/agent-identity-discovery](https://github.com/agent-community/agent-identity-discovery)
 
-Exposes the shared `test-fixtures/golden.json` via a typed export (includes v1.1 fields like `docs`/`dep` and `pka`/`kid`) and provides a simple Node runner to execute the fixtures against a parser.
+Exposes the shared fixture packs via typed exports:
+
+- `golden.json` for parser parity across languages
+- `enterprise.json` for enterprise discovery and security vectors used by the reference implementation
+
+It also provides a simple Node runner to execute the parser fixtures against a parser.
 
 ## Install
 
@@ -29,18 +34,22 @@ npm i -D @agentcommunity/aid-conformance
 ## Usage (Node / TypeScript)
 
 ```ts
-import { fixtures, type GoldenFixture } from '@agentcommunity/aid-conformance';
+import { fixtures, enterpriseFixtures, type GoldenFixture } from '@agentcommunity/aid-conformance';
 import { parse } from '@agentcommunity/aid';
 
 for (const c of fixtures.records) {
   const record = parse(c.raw);
   // assert deep equality with c.expected
 }
+
+for (const c of enterpriseFixtures.securityPolicies) {
+  console.log(c.name, c.runtime);
+}
 ```
 
 To use from other language repos, consume the published package tarball as a dev artifact or copy the JSON path after installation:
 
-- The JSON is reused from the repo at `test-fixtures/golden.json` and is included in the published bundle (no duplication in source).
+- The JSON is reused from the repo at `test-fixtures/golden.json` and `test-fixtures/enterprise.json` and is included in the published bundle (no duplication in source).
 
 ## CLI
 

--- a/packages/aid-conformance/src/index.test.ts
+++ b/packages/aid-conformance/src/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { fixtures } from './index.js';
+import { enterpriseFixtures, fixtures } from './index.js';
 
 describe('aid-conformance fixtures', () => {
   it('should expose records with name/raw/expected', () => {
@@ -12,6 +12,17 @@ describe('aid-conformance fixtures', () => {
       expect(c.expected.v).toBe('aid1');
       expect(typeof c.expected.uri).toBe('string');
       expect(typeof c.expected.proto).toBe('string');
+    }
+  });
+
+  it('should expose enterprise security policy vectors', () => {
+    expect(Array.isArray(enterpriseFixtures.securityPolicies)).toBe(true);
+    for (const c of enterpriseFixtures.securityPolicies) {
+      expect(typeof c.name).toBe('string');
+      expect(c.runtime === 'node' || c.runtime === 'browser').toBe(true);
+      expect(typeof c.queryName).toBe('string');
+      expect(typeof c.options).toBe('object');
+      expect(typeof c.expect).toBe('object');
     }
   });
 });

--- a/packages/aid-conformance/src/index.ts
+++ b/packages/aid-conformance/src/index.ts
@@ -14,6 +14,7 @@ export type AidRecord = {
 // Re-export the shared golden fixtures without duplicating the file.
 // Using a relative path to the repository-level fixture per instruction.
 import golden from '../../../test-fixtures/golden.json';
+import enterprise from '../../../test-fixtures/enterprise.json';
 
 export type GoldenRecordCase = {
   name: string;
@@ -27,3 +28,28 @@ export type GoldenFixture = {
 };
 
 export const fixtures: GoldenFixture = golden as unknown as GoldenFixture;
+
+export type EnterprisePolicyCase = {
+  name: string;
+  runtime: 'node' | 'browser';
+  queryName: string;
+  options: Record<string, unknown>;
+  dns: {
+    answers?: Array<{ name: string; data: string; ttl: number }>;
+    errorCode?: string;
+    ad?: boolean;
+  };
+  wellKnown?: {
+    body?: Record<string, unknown>;
+  };
+  expect: {
+    errorCode?: string;
+    warningCodes?: string[];
+  };
+};
+
+export type EnterpriseFixture = {
+  securityPolicies: EnterprisePolicyCase[];
+};
+
+export const enterpriseFixtures: EnterpriseFixture = enterprise as unknown as EnterpriseFixture;

--- a/packages/aid-dotnet/tests/ParityTests.cs
+++ b/packages/aid-dotnet/tests/ParityTests.cs
@@ -5,7 +5,8 @@ namespace AidDiscovery.Tests;
 public class ParityTests
 {
     private record FixtureRecord(string name, string raw, Dictionary<string, string> expected);
-    private record FixtureRoot(List<FixtureRecord> records);
+    private record InvalidFixtureRecord(string name, string raw, string errorCode);
+    private record FixtureRoot(List<FixtureRecord> records, List<InvalidFixtureRecord>? invalid);
 
     [Fact]
     public void GoldenParity()
@@ -32,6 +33,12 @@ public class ParityTests
             if (parsed.Kid is not null) got["kid"] = parsed.Kid;
 
             Assert.Equivalent(rec.expected, got);
+        }
+
+        foreach (var rec in fx.invalid ?? [])
+        {
+            var err = Assert.Throws<AidError>(() => Aid.Parse(rec.raw));
+            Assert.Equal(rec.errorCode, err.ErrorCode);
         }
     }
 

--- a/packages/aid-go/parity_test.go
+++ b/packages/aid-go/parity_test.go
@@ -16,6 +16,11 @@ type parityRecord struct {
 
 type parityRoot struct {
 	Records []parityRecord `json:"records"`
+	Invalid []struct {
+		Name      string `json:"name"`
+		Raw       string `json:"raw"`
+		ErrorCode string `json:"errorCode"`
+	} `json:"invalid"`
 }
 
 func TestParity(t *testing.T) {
@@ -66,6 +71,22 @@ func TestParity(t *testing.T) {
 			jg, _ := json.Marshal(got)
 			je, _ := json.Marshal(rec.Expected)
 			t.Errorf("%s: mismatch\n got %s\nwant %s", rec.Name, string(jg), string(je))
+		}
+	}
+
+	for _, rec := range fx.Invalid {
+		_, err := Parse(rec.Raw)
+		if err == nil {
+			t.Errorf("%s: expected parse error", rec.Name)
+			continue
+		}
+		aidErr, ok := err.(*AidError)
+		if !ok {
+			t.Errorf("%s: expected AidError, got %T", rec.Name, err)
+			continue
+		}
+		if rec.ErrorCode != "" && aidErr.Symbol != rec.ErrorCode {
+			t.Errorf("%s: got error %s, want %s", rec.Name, aidErr.Symbol, rec.ErrorCode)
 		}
 	}
 }

--- a/packages/aid-py/tests/test_parity.py
+++ b/packages/aid-py/tests/test_parity.py
@@ -20,4 +20,12 @@ def test_parity():
     for rec in _fixture["records"]:
         parsed = parse(rec["raw"])
         # Convert TypedDict to plain dict for comparison
-        assert dict(parsed) == rec["expected"] 
+        assert dict(parsed) == rec["expected"]
+
+    for rec in _fixture.get("invalid", []):
+        try:
+            parse(rec["raw"])
+        except Exception as exc:  # noqa: BLE001
+            assert getattr(exc, "error_code", None) == rec.get("errorCode")
+        else:
+            raise AssertionError(f'{rec["name"]}: expected parse failure')

--- a/packages/aid-rs/tests/parity.rs
+++ b/packages/aid-rs/tests/parity.rs
@@ -32,20 +32,14 @@ fn parity_from_golden() {
             assert_eq!(val, v.as_str().unwrap_or_default(), "key {} mismatch", k);
         }
     }
-}
-
-#[test]
-fn invalid_cases_error_codes() {
-    let err = parse("uri=https://x;p=mcp").unwrap_err();
-    assert_eq!(err.error_code, "ERR_INVALID_TXT");
-
-    let err = parse("v=aid1;uri=https://x;proto=mcp;p=mcp").unwrap_err();
-    assert_eq!(err.error_code, "ERR_INVALID_TXT");
-
-    let err = parse("v=aid1;uri=https://x;p=foo").unwrap_err();
-    assert_eq!(err.error_code, "ERR_UNSUPPORTED_PROTO");
-
-    let long_desc = "a".repeat(61);
-    let err = parse(&format!("v=aid1;uri=https://x;p=mcp;desc={}", long_desc)).unwrap_err();
-    assert_eq!(err.error_code, "ERR_INVALID_TXT");
+    let invalid = v.get("invalid").and_then(|r| r.as_array()).expect("invalid array");
+    for rec in invalid {
+        let raw = rec.get("raw").and_then(|s| s.as_str()).expect("raw string");
+        let expected = rec
+            .get("errorCode")
+            .and_then(|s| s.as_str())
+            .expect("errorCode string");
+        let err = parse(raw).expect_err("parse should fail");
+        assert_eq!(err.error_code, expected, "invalid case mismatch");
+    }
 }

--- a/packages/aid/src/parity.test.ts
+++ b/packages/aid/src/parity.test.ts
@@ -13,13 +13,26 @@ interface FixtureRecord {
 
 const __dirnameFix = path.dirname(fileURLToPath(import.meta.url));
 const fixturePath = path.resolve(__dirnameFix, '../../..', 'test-fixtures', 'golden.json');
-const fixture = JSON.parse(fs.readFileSync(fixturePath, 'utf8')) as { records: FixtureRecord[] };
+const fixture = JSON.parse(fs.readFileSync(fixturePath, 'utf8')) as {
+  records: FixtureRecord[];
+  invalid?: Array<{ name: string; raw: string; errorCode?: string }>;
+};
 
 describe('cross-language parity – TypeScript parser', () => {
   for (const rec of fixture.records) {
     it(`parses ${rec.name}`, () => {
       const parsed = parse(rec.raw);
       expect(parsed).toEqual(rec.expected);
+    });
+  }
+
+  for (const rec of fixture.invalid ?? []) {
+    it(`rejects invalid fixture ${rec.name}`, () => {
+      expect(() => parse(rec.raw)).toThrowError(
+        expect.objectContaining({
+          errorCode: rec.errorCode,
+        }),
+      );
     });
   }
 });

--- a/test-fixtures/enterprise.json
+++ b/test-fixtures/enterprise.json
@@ -1,0 +1,133 @@
+{
+  "securityPolicies": [
+    {
+      "name": "node-strict-requires-pka",
+      "runtime": "node",
+      "queryName": "_agent.example.com",
+      "options": {
+        "securityMode": "strict"
+      },
+      "dns": {
+        "answers": [
+          {
+            "name": "_agent.example.com",
+            "data": "v=aid1;u=https://api.example.com/mcp;p=mcp",
+            "ttl": 300
+          }
+        ]
+      },
+      "expect": {
+        "errorCode": "ERR_SECURITY"
+      }
+    },
+    {
+      "name": "node-balanced-warns-on-missing-dnssec",
+      "runtime": "node",
+      "queryName": "_agent.example.com",
+      "options": {
+        "securityMode": "balanced"
+      },
+      "dns": {
+        "answers": [
+          {
+            "name": "_agent.example.com",
+            "data": "v=aid1;u=https://api.example.com/mcp;p=mcp",
+            "ttl": 300
+          }
+        ],
+        "ad": false
+      },
+      "expect": {
+        "warningCodes": ["DNSSEC_PREFERRED"]
+      }
+    },
+    {
+      "name": "node-strict-disables-well-known",
+      "runtime": "node",
+      "queryName": "_agent.example.com",
+      "options": {
+        "securityMode": "strict"
+      },
+      "dns": {
+        "errorCode": "ERR_NO_RECORD"
+      },
+      "wellKnown": {
+        "body": {
+          "v": "aid1",
+          "u": "https://api.example.com/mcp",
+          "p": "mcp"
+        }
+      },
+      "expect": {
+        "errorCode": "ERR_NO_RECORD"
+      }
+    },
+    {
+      "name": "browser-strict-requires-dnssec",
+      "runtime": "browser",
+      "queryName": "_agent.example.com",
+      "options": {
+        "securityMode": "strict"
+      },
+      "dns": {
+        "answers": [
+          {
+            "name": "_agent.example.com",
+            "data": "v=aid1;u=https://api.example.com/mcp;p=mcp;k=zBase58EncodedKey;i=g1",
+            "ttl": 300
+          }
+        ],
+        "ad": false
+      },
+      "expect": {
+        "errorCode": "ERR_SECURITY"
+      }
+    },
+    {
+      "name": "node-downgrade-fail",
+      "runtime": "node",
+      "queryName": "_agent.example.com",
+      "options": {
+        "dnssecPolicy": "off",
+        "downgradePolicy": "fail",
+        "previousSecurity": {
+          "pka": "zOldKey",
+          "kid": "g1"
+        }
+      },
+      "dns": {
+        "answers": [
+          {
+            "name": "_agent.example.com",
+            "data": "v=aid1;u=https://api.example.com/mcp;p=mcp",
+            "ttl": 300
+          }
+        ]
+      },
+      "expect": {
+        "errorCode": "ERR_SECURITY"
+      }
+    },
+    {
+      "name": "browser-strict-disables-well-known",
+      "runtime": "browser",
+      "queryName": "_agent.example.com",
+      "options": {
+        "securityMode": "strict"
+      },
+      "dns": {
+        "errorCode": "ERR_NO_RECORD"
+      },
+      "wellKnown": {
+        "body": {
+          "v": "aid1",
+          "u": "https://api.example.com/mcp",
+          "p": "mcp"
+        }
+      },
+      "expect": {
+        "errorCode": "ERR_NO_RECORD"
+      }
+    }
+  ]
+}

--- a/test-fixtures/golden.json
+++ b/test-fixtures/golden.json
@@ -57,6 +57,21 @@
       "name": "pka-missing-kid",
       "raw": "v=aid1;uri=https://api.example.com/mcp;p=mcp;k=z111",
       "errorCode": "ERR_INVALID_TXT"
+    },
+    {
+      "name": "duplicate-proto-fields",
+      "raw": "v=aid1;uri=https://api.example.com/mcp;proto=mcp;p=mcp",
+      "errorCode": "ERR_INVALID_TXT"
+    },
+    {
+      "name": "unsupported-proto",
+      "raw": "v=aid1;uri=https://api.example.com/mcp;proto=unknown",
+      "errorCode": "ERR_UNSUPPORTED_PROTO"
+    },
+    {
+      "name": "remote-non-https",
+      "raw": "v=aid1;uri=http://api.example.com/mcp;proto=mcp",
+      "errorCode": "ERR_INVALID_TXT"
     }
   ]
 }


### PR DESCRIPTION
Closes #101

## Summary
- expand shared parser parity fixtures with additional invalid cases
- add shared `enterprise.json` security/discovery vectors and export them from `@agentcommunity/aid-conformance`
- broaden parity consumers across TS, Go, Python, Rust, .NET, and Java
- make the top-level `test:parity` command gate the conformance fixture package itself

## Validation
- `pnpm test:parity`
- `cd packages/aid-rs && cargo test parity -- --nocapture`
- `dotnet test packages/aid-dotnet/AidDiscovery.sln -c Release --no-restore --filter GoldenParity`
- `./gradlew --no-daemon :aid-java:test --tests '*ParityTest*'`
