### PR TITLE
docs(enterprise): add rollout playbook

### DIFF
--- a/packages/docs/Reference/enterprise_rollout.md
+++ b/packages/docs/Reference/enterprise_rollout.md
@@ -1,0 +1,259 @@
+---
+title: 'Enterprise Rollout'
+description: 'Rollout playbook for DNS teams and application teams adopting AID in production.'
+icon: material/clipboard-check-outline
+---
+
+# Enterprise Rollout Playbook
+
+Use this playbook when DNS ownership and application ownership are split across teams.
+
+AID rollout usually fails on coordination, not syntax. Treat the `_agent.<domain>` record, DNSSEC, TLS, and PKA as one change set.
+
+## Ownership Model
+
+Split responsibilities clearly before the first rollout.
+
+### DNS team
+
+- Own the `_agent.<domain>` TXT record.
+- Own DNSSEC enablement and DS record publication.
+- Own TTL changes and rollback windows.
+- Own delegated subdomain records when the application team does not control the parent zone.
+
+### Application team
+
+- Own the agent endpoint, TLS certificate, and protocol behavior.
+- Own `pka` and `kid` generation, storage, and rotation.
+- Own `.well-known` only when that fallback is intentionally allowed.
+- Own post-change verification with `aid-doctor` and SDK smoke tests.
+
+### Shared handoff
+
+Agree on these values before rollout:
+
+- queried hostname
+- published `_agent` name
+- target `uri`
+- `proto`
+- TTL during change window
+- DNSSEC expectation
+- PKA requirement
+- rollback owner
+
+## Deployment Patterns
+
+AID discovery is exact-host only. Do not rely on parent-domain walking.
+
+### Pattern A: apex or standard host deployment
+
+Use this when the domain itself should resolve directly.
+
+```dns
+_agent.example.com. 300 IN TXT "v=aid1;u=https://api.example.com/mcp;p=mcp;i=g1;k=z6Mk..."
+```
+
+Use this for:
+
+- `example.com`
+- `api.example.com`
+- `agent.example.com`
+
+### Pattern B: delegated subdomain deployment
+
+Use this when the application team needs isolated control.
+
+Parent zone:
+
+```dns
+_agent.team.example.com. 300 IN NS ns1.team-dns.example.net.
+_agent.team.example.com. 300 IN NS ns2.team-dns.example.net.
+```
+
+Delegated zone:
+
+```dns
+_agent.app.team.example.com. 300 IN TXT "v=aid1;u=https://app.team.example.com/mcp;p=mcp;i=g1;k=z6Mk..."
+```
+
+Use this when:
+
+- the DNS team owns `example.com`
+- the app team owns `team.example.com` or a delegated `_agent` subtree
+- you need team-level isolation without changing client discovery behavior
+
+Do not publish multiple valid AID TXT records at the same queried name. Use distinct hostnames or route behind one endpoint.
+
+## Rollout Sequence
+
+Use a controlled change window.
+
+### 1. Prepare
+
+- Lower TTL to `60-120` seconds if you expect a near-term cutover.
+- Confirm the endpoint is live before DNS changes.
+- Generate `pka` and `kid` if the environment will use `balanced` or `strict` with identity proof.
+- Decide whether `.well-known` fallback is allowed. In `strict`, it is not.
+
+### 2. Validate before publish
+
+Run:
+
+```bash
+aid-doctor check example.com --security-mode balanced --check-downgrade
+```
+
+For stricter environments, run:
+
+```bash
+aid-doctor check example.com --security-mode strict --check-downgrade
+```
+
+Confirm:
+
+- exactly one valid record exists
+- remote endpoints use `https://` or `wss://`
+- DNSSEC status matches policy
+- `pka` verification passes when required
+
+### 3. Publish
+
+- Publish the TXT record at the exact queried host.
+- Publish DS records and enable DNSSEC before requiring it in client policy.
+- If rotating keys, deploy the new private key before updating DNS.
+
+### 4. Verify after publish
+
+Run:
+
+```bash
+aid-doctor check example.com --security-mode balanced --check-downgrade
+```
+
+Then run one SDK smoke test from the client environment that will actually consume the record.
+
+### 5. Restore TTL
+
+After caches settle and validation stays clean, restore the normal TTL.
+
+## Security Mode Adoption Ladder
+
+Do not start with `strict` unless DNSSEC and PKA are already operational.
+
+### Stage 1: baseline
+
+Use default discovery behavior while the DNS and app teams prove basic correctness.
+
+Exit criteria:
+
+- exact-host record is stable
+- TLS is valid
+- no duplicate valid TXT records exist
+
+### Stage 2: `balanced`
+
+Use `balanced` when you want warnings instead of hard failures.
+
+- `pka`: `if-present`
+- `dnssec`: `prefer`
+- `well-known`: `auto`
+- `downgrade`: `warn`
+
+Exit criteria:
+
+- PKA is deployed and verifiable where expected
+- DNSSEC is live or the remaining gap is explicitly accepted
+- downgrade warnings are monitored
+
+### Stage 3: `strict`
+
+Use `strict` only after the organization can support hard failures.
+
+- `pka`: `require`
+- `dnssec`: `require`
+- `well-known`: `disable`
+- `downgrade`: `fail`
+
+Exit criteria:
+
+- DNSSEC validation works from real client networks
+- PKA rotation runbook has been exercised
+- teams agree on rollback ownership and escalation path
+
+## Rollback Guidance
+
+Treat rollback as part of the rollout plan.
+
+### DNS rollback
+
+- restore the last known good TXT record
+- keep the same queried hostname
+- keep TTL low until validation recovers
+- rerun `aid-doctor check <domain>`
+
+### PKA rollback
+
+- restore the previous private key only if it is still trusted and available
+- otherwise publish a new `pka` with a new `kid`
+- do not remove `pka` silently if clients may have downgrade memory enabled
+
+### DNSSEC rollback
+
+- avoid disabling DNSSEC during an incident unless the DNS team is sure DS and signing state are the root cause
+- if `strict` clients exist, disabling DNSSEC is a breaking change
+
+## Incident Runbooks
+
+### Downgrade alert: `pka` missing or `kid` changed
+
+1. Confirm whether a planned rotation or rollback happened.
+2. Compare the current DNS answer with the last known good value.
+3. If the change was expected, document it and update caches or rollout notes.
+4. If the change was not expected, treat it as a security incident and revert to a known good state.
+
+### Multiple valid TXT records detected
+
+1. Inspect authoritative DNS, not only recursive resolver output.
+2. Remove duplicate valid AID payloads at the queried name.
+3. Keep one valid record only.
+4. If multiple agents are needed, move them to distinct hostnames.
+
+### Exact-host lookup failed after delegation
+
+1. Confirm the client is querying the intended hostname.
+2. Confirm the delegated `_agent` zone exists and serves the target name.
+3. Confirm the parent zone does not rely on implicit inheritance.
+4. Verify with `dig` and `aid-doctor` from outside the authoritative network.
+
+## Enterprise Checklist
+
+### Before rollout
+
+- [ ] DNS team and app team owners named
+- [ ] exact queried hostname agreed
+- [ ] rollback owner named
+- [ ] TTL lowered for cutover if needed
+- [ ] endpoint deployed and TLS valid
+- [ ] PKA key pair generated and stored securely if used
+- [ ] DNSSEC plan confirmed
+
+### During rollout
+
+- [ ] exactly one valid TXT record published
+- [ ] `aid-doctor check <domain>` passes in the target security mode
+- [ ] one real SDK/client smoke test passes
+- [ ] logs and alerting are monitored during propagation
+
+### After rollout
+
+- [ ] TTL restored
+- [ ] rollback notes updated
+- [ ] downgrade baseline stored if applicable
+- [ ] key rotation procedure documented and assigned
+
+## See Also
+
+- [Specification](../specification.md)
+- [Security Best Practices](security.md)
+- [Discovery API](discovery_api.md)
+- [aid-doctor CLI](../Tooling/aid_doctor.md)

--- a/packages/docs/Reference/meta.json
+++ b/packages/docs/Reference/meta.json
@@ -6,6 +6,7 @@
     "identity_pka",
     "well_known_json",
     "security",
+    "enterprise_rollout",
     "versioning",
     "troubleshooting"
   ]

--- a/packages/docs/Reference/security.md
+++ b/packages/docs/Reference/security.md
@@ -184,8 +184,11 @@ Use this checklist when deploying or auditing an AID record.
 
 Use the [aid-doctor CLI](../Tooling/aid_doctor.md) to automate validation and security checks.
 
+For production adoption across separate DNS and application owners, follow the [Enterprise Rollout Playbook](enterprise_rollout.md).
+
 ## See Also
 
 - [Identity & PKA](identity_pka.md) — Full PKA handshake details
+- [Enterprise Rollout](enterprise_rollout.md) — DNS team and application team rollout checklist
 - [Specification](../specification.md) — Normative security requirements
 - [Troubleshooting](troubleshooting.md) — Common security-related errors

--- a/packages/docs/Tooling/aid_doctor.md
+++ b/packages/docs/Tooling/aid_doctor.md
@@ -180,3 +180,5 @@ aid-doctor pka verify --key <z...>
 - For dev-only loopback `.well-known`, set `AID_ALLOW_INSECURE_WELL_KNOWN=1`.
 - Use `--save-draft` with `generate` to save records for later deployment.
 - Error messages are standardized for consistent troubleshooting experience.
+
+For change windows, ownership split, and staged `balanced` to `strict` adoption, see the [Enterprise Rollout Playbook](../Reference/enterprise_rollout.md).

--- a/packages/docs/export-manifest.json
+++ b/packages/docs/export-manifest.json
@@ -4,8 +4,8 @@
   "files": [
     {
       "path": "index.md",
-      "bytes": 4651,
-      "sha256": "0f2f9823422b1342689d2d305467d45e5e7cc8e2ec7242f3b81428e038d0cd2c"
+      "bytes": 4790,
+      "sha256": "9d45d832a0efec55a8661535579095fddf2834e1e3facbd739babc38c77ab535"
     },
     {
       "path": "quickstart/index.md",
@@ -68,6 +68,11 @@
       "sha256": "1a16d952228e4e8a0b989e267be6e5a7a3cff4605abb86d1d1e638943f2d2821"
     },
     {
+      "path": "Reference/enterprise_rollout.md",
+      "bytes": 7150,
+      "sha256": "b82753726b18849922eca142dd325df9981dc66cd32a7bdf3d161c3ee4840f21"
+    },
+    {
       "path": "Reference/identity_pka.md",
       "bytes": 6055,
       "sha256": "723a263961982965c1f46248cadb9ce335e5a2ff70962bd8eede009ba7503fe1"
@@ -79,8 +84,8 @@
     },
     {
       "path": "Reference/security.md",
-      "bytes": 8976,
-      "sha256": "a403b3bff934511db84dd9013ad4947f05e5674d9f657b5a851e27a97ab8a392"
+      "bytes": 9208,
+      "sha256": "584dcb24ce0f113cae49c2b6d4079444dd31b14f9ed81b546d392923e2196d31"
     },
     {
       "path": "Reference/troubleshooting.md",
@@ -99,13 +104,13 @@
     },
     {
       "path": "specification.md",
-      "bytes": 19968,
-      "sha256": "c1d154b2498a1b173124539fd39fe31e056c90a97ed2037a2b36793b1d527763"
+      "bytes": 20091,
+      "sha256": "a8b9d05da388a744952857a2ec2036996ea32e4e68cd9f389490d54fd91adb50"
     },
     {
       "path": "Tooling/aid_doctor.md",
-      "bytes": 6316,
-      "sha256": "53168ac068e4e3622a0e0e432c9c035403572b385193b1e15c2c2e055fcf342b"
+      "bytes": 6473,
+      "sha256": "29637f92d46d48c875b246f9d807fb0eddda3e3f5c99aaaa44cbb6302c82be4a"
     },
     {
       "path": "Tooling/aid_engine.md",
@@ -138,5 +143,5 @@
       "sha256": "985c0214d91997524c53b078da3a8b87599709ee71c1d39b0cfa96764bcbd117"
     }
   ],
-  "aggregateSha256": "bb6b04ec8c3de678f88dd17bfab9f025c7a2dc48d54fe7a2825289f9831a6289"
+  "aggregateSha256": "5fbc1084a7f8b2417a0cf2faa08afb60f42c32cae93fcba9e3aa3de474c65471"
 }

--- a/packages/docs/export-manifest.sha256
+++ b/packages/docs/export-manifest.sha256
@@ -1,1 +1,1 @@
-bb6b04ec8c3de678f88dd17bfab9f025c7a2dc48d54fe7a2825289f9831a6289  export-manifest.json
+5fbc1084a7f8b2417a0cf2faa08afb60f42c32cae93fcba9e3aa3de474c65471  export-manifest.json

--- a/packages/docs/index.md
+++ b/packages/docs/index.md
@@ -69,6 +69,7 @@ flowchart LR
 - [**Identity & PKA**](Reference/identity_pka.md) – _How AID provides cryptographic proof of an agent's identity._
 - [**Rationale**](Understand/rationale.md) – _The design philosophy behind AID._
 - [**Security Best Practices**](Reference/security.md) – _DNSSEC, redirect handling, local execution, IDN safety, TTL & caching._
+- [**Enterprise Rollout**](Reference/enterprise_rollout.md) – _Change windows, delegation patterns, and DNS team vs app team ownership._
 - [**aid-doctor CLI**](Tooling/aid_doctor.md) – _Validate, secure, and generate AID records._
 
 ---

--- a/packages/docs/specification.md
+++ b/packages/docs/specification.md
@@ -215,6 +215,8 @@ Policy semantics:
 
 If discovery succeeds only through `.well-known`, that result cannot satisfy `dnssec=require`.
 
+Operational rollout guidance for these modes lives in the [Enterprise Rollout Playbook](Reference/enterprise_rollout.md).
+
 ---
 
 ## **4. DNS and Caching**


### PR DESCRIPTION
## Summary
- add a dedicated enterprise rollout playbook for DNS teams and application teams
- link the playbook from the spec, security guide, aid-doctor docs, and docs index
- regenerate docs export manifest metadata

## Validation
- pnpm docs:verify

Closes #102