### PR TITLE
docs(quickstart): add key legend and SDK field-mapping note

### DIFF
--- a/packages/docs/export-manifest.json
+++ b/packages/docs/export-manifest.json
@@ -9,8 +9,8 @@
     },
     {
       "path": "quickstart/index.md",
-      "bytes": 10224,
-      "sha256": "f5aab7ecb9903c0c7fc276374fc6fe6ef49d1c84a3e6a0e6050762cf55a38cea"
+      "bytes": 10770,
+      "sha256": "ac53eaa506c203b07a07341901160a67cfcd1e99ac3dd0490fd0e5f70c44e701"
     },
     {
       "path": "quickstart/quickstart_a2a.md",
@@ -143,5 +143,5 @@
       "sha256": "985c0214d91997524c53b078da3a8b87599709ee71c1d39b0cfa96764bcbd117"
     }
   ],
-  "aggregateSha256": "55ee477c891099ce92efdaf2ab2b3af8fa4260722dbc65b3548edd755b228a84"
+  "aggregateSha256": "c01f9fc1d25a38d859f55c600d0fd4c0887afc32e09486167863a45d9a89b991"
 }

--- a/packages/docs/export-manifest.sha256
+++ b/packages/docs/export-manifest.sha256
@@ -1,1 +1,1 @@
-55ee477c891099ce92efdaf2ab2b3af8fa4260722dbc65b3548edd755b228a84  export-manifest.json
+c01f9fc1d25a38d859f55c600d0fd4c0887afc32e09486167863a45d9a89b991  export-manifest.json

--- a/packages/docs/quickstart/index.md
+++ b/packages/docs/quickstart/index.md
@@ -60,6 +60,8 @@ v=aid1;u=https://api.my-cool-saas.com/agent/v1;p=mcp;s=My Cool SaaS AI
 
 **Plus validation:** The CLI automatically validates your record format, URI scheme, and protocol tokens before generating.
 
+> **Key reference:** AID records use short wire keys for compactness. `v`=version, `u`=uri, `p`=protocol, `a`=auth, `s`=description, `d`=docs url, `e`=deprecation, `k`=public key, `i`=key id. You do not need to memorize these because the CLI and [Live Generator](https://aid.agentcommunity.org/workbench) handle them for you. See the [Specification](../specification.md) for the complete key table.
+
 ### Option B: Manual Generation
 
 If you prefer to craft the record manually:
@@ -119,6 +121,8 @@ nslookup -q=TXT _agent.my-cool-saas.com
 ---
 
 ## Part 2: For Clients (Discovering an Agent)
+
+> SDKs parse short wire keys (`v`, `u`, `p`, ...) into descriptive field names (`proto`, `uri`, `desc`, ...) so application code stays readable.
 
 Now let's write code to find an agent. We provide libraries in several languages to make this trivial.
 


### PR DESCRIPTION
## Summary
- add a concise key legend in Quick Start after the first generated TXT example
- add an SDK mapping note clarifying short wire keys map to descriptive SDK field names
- keep wording aligned with canonical short-key v1.x format

## Validation
- pnpm docs:verify

Supersedes #100