### PR TITLE
fix(aid-doctor): normalize publish metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "author": "Agent Community",
   "repository": {
     "type": "git",
-    "url": "https://github.com/agentcommunity/agent-identity-discovery.git"
+    "url": "git+https://github.com/agentcommunity/agent-identity-discovery.git"
   },
   "engines": {
     "node": ">=20.18.0",

--- a/packages/aid-doctor/package.json
+++ b/packages/aid-doctor/package.json
@@ -14,7 +14,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/agentcommunity/agent-identity-discovery.git",
+    "url": "git+https://github.com/agentcommunity/agent-identity-discovery.git",
     "directory": "packages/aid-doctor"
   },
   "homepage": "https://aid.agentcommunity.org",
@@ -33,7 +33,7 @@
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "bin": {
-    "aid-doctor": "./dist/cli.js"
+    "aid-doctor": "dist/cli.js"
   },
   "files": [
     "dist/**/*",

--- a/packages/aid-doctor/src/cli.test.ts
+++ b/packages/aid-doctor/src/cli.test.ts
@@ -260,7 +260,7 @@ describe('AID Doctor CLI', () => {
 
       expect(packageJson.name).toBe('@agentcommunity/aid-doctor');
       expect(packageJson.bin).toBeDefined();
-      expect(packageJson.bin['aid-doctor']).toBe('./dist/cli.js');
+      expect(packageJson.bin['aid-doctor']).toBe('dist/cli.js');
     });
 
     it('uses package.json as the commander version source', async () => {


### PR DESCRIPTION
## Summary
- normalize repository URL metadata for npm publishing
- publish the aid-doctor bin path in npm's accepted normalized form
- update the package integrity assertion to match the publish-safe manifest

## Verification
- pnpm -C packages/aid-doctor test
- pnpm -C packages/aid-doctor pack --pack-destination /tmp/aid-doctor-pack-normalized-verify-2
- temp npm install of packed tarball and ./node_modules/.bin/aid-doctor --version / --help