### PR TITLE
Align AID web examples with v2 PKA

### DIFF
--- a/packages/aid-engine/src/checker.test.ts
+++ b/packages/aid-engine/src/checker.test.ts
@@ -147,6 +147,11 @@ describe('runCheck security-state downgrade cache', () => {
 
     const report = await check();
 
+    expect(report.pka).toMatchObject({
+      present: true,
+      kid: null,
+      keyid: ZERO_THUMBPRINT,
+    });
     expect(report.cacheEntry).toMatchObject({
       version: 'aid2',
       trustSource: 'dns',

--- a/packages/aid-engine/src/checker.ts
+++ b/packages/aid-engine/src/checker.ts
@@ -154,6 +154,7 @@ function initReport(domain: string, protocol?: string): DoctorReport {
       attempted: false,
       verified: null,
       kid: null,
+      keyid: null,
       alg: null,
       createdSkewSec: null,
       covered: null,
@@ -308,8 +309,10 @@ export async function runCheck(domain: string, opts: CheckOptions): Promise<Doct
     }
 
     if (record.pka) {
+      const keyMaterial = derivePkaKeyid(record.pka);
       report.pka.present = true;
       report.pka.kid = record.v === 'aid1' ? (record.kid ?? null) : null;
+      report.pka.keyid = keyMaterial?.keyid ?? null;
       report.pka.alg = 'ed25519';
       report.pka.attempted = true;
       try {

--- a/packages/aid-engine/src/types.ts
+++ b/packages/aid-engine/src/types.ts
@@ -83,6 +83,7 @@ export interface PkaBlock {
   attempted: boolean;
   verified: boolean | null;
   kid: string | null;
+  keyid: string | null;
   alg: string | null;
   createdSkewSec: number | null;
   covered: string[] | null;

--- a/packages/docs/Understand/rationale.md
+++ b/packages/docs/Understand/rationale.md
@@ -21,7 +21,7 @@ This document provides the rationale behind the design decisions in the Agent Id
 
 The design of AID is guided by a single, overarching principle: **Pragmatism over Purity**. Our goal is to create a standard that is immediately useful and adoptable by the widest possible audience. This led to three core tenets:
 
-1.  **Embrace Existing Infrastructure:** The protocol leverages DNS TXT records, a technology that is universally supported, well-understood, and configurable by every domain owner on the planet. It avoids dependencies on newer, less-adopted standards or centralized services.
+1.  **Embrace Existing Infrastructure:** The protocol leverages DNS TXT records, a technology that is widely supported, well-understood, and configurable through ordinary DNS hosting and registrar workflows. It avoids making newer or less universally exposed record types mandatory for the first-contact path.
 2.  **Minimize Complexity:** The v2 specification is intentionally lean. It solves one problem and one problem only: _discovering the primary entry point for an agent service_. By resisting the temptation to solve adjacent problems (like capability negotiation or rich configuration), AID remains simple to implement for both providers and clients.
 3.  **Default to Decentralization:** The protocol is inherently decentralized. There is no central registry, no required registration, and no single point of failure. If you own a domain, you can publish an AID record. This aligns with the foundational principles of the open internet.
 
@@ -29,7 +29,7 @@ The design of AID is guided by a single, overarching principle: **Pragmatism ove
 
 The minimalist design of AID delivers several key advantages:
 
-- **Ubiquitous and Immediate Deployability:** By using DNS TXT records, any service provider can implement AID today without waiting for new infrastructure to be deployed. Client libraries can be built with standard DNS resolvers available in every major programming language.
+- **Ubiquitous and Immediate Deployability:** By using DNS TXT records, service providers can implement AID today without waiting for new infrastructure to be deployed. Client libraries can be built with standard DNS resolvers available in every major programming language. See [Why AID ships on TXT records](https://agentcommunity.org/blog/why-txt-records) for the deployment argument behind this choice.
 - **Unambiguous and Namespace-Safe Discovery:** The `_agent.<domain>` subdomain follows established conventions for service discovery ([RFC8552]), preventing collisions and keeping the root domain clean. The non-normative guidance for protocol-specific subdomains (e.g., `_agent._mcp.<domain>`) further demonstrates this flexibility.
 - **Human-Readable and Easily Debuggable:** The `key=value` format is simple to read and write. A developer can debug any AID record with a single command (`dig TXT _agent.example.com`) without needing special tools, which dramatically lowers the barrier to entry. The optional `p` alias for `proto` is a minor but thoughtful concession to brevity in this human-readable context.
 - **Superior User Experience via the `desc` Key:** The optional `desc` key is a small but critical feature. It allows a client to provide human-readable context _before_ a connection is made (e.g., "Connect to 'Google's AI Tools'?"), which builds user trust and clarity.
@@ -69,7 +69,7 @@ A successful standard is defined as much by the problems it _doesn't_ solve as b
 ### **5. Alternatives Considered and Rejected**
 
 - **Full `aid.json` Manifest:** While powerful for describing complex local and remote implementations, the manifest-based approach was deemed too burdensome for the core standard. It required providers to host and maintain a JSON file, and clients to implement a significantly more complex resolution and validation logic. The `proto=local` token captures much of the manifest's value with less complexity.
-- **DNS `SRV` or `HTTPS/SVCB` Records:** These are technically more "correct" for service discovery. However, they lack the universal, simple configuration support of `TXT` records in many DNS providers' dashboards. Furthermore, client-side resolver support is not yet ubiquitous. For v2, `TXT` offers the path of least resistance to adoption, with a clear migration path to `SRV`/`HTTPS` in the future.
+- **DNS `SRV` or `HTTPS/SVCB` Records:** These are valuable service-discovery and service-binding mechanisms, and future AID profiles or adjacent discovery systems may use them. They are not the mandatory v2 baseline because AID optimizes for the smallest deployable first-contact hop: one compact TXT record that ordinary domain owners can publish and ordinary clients can query. TXT keeps experimentation and adoption cheap while the richer service-binding design space remains open.
 - **Centralized Registry:** A central "Agent Store" or registry was rejected as it violates the principle of decentralization, creates a single point of failure, and introduces a gatekeeper to the ecosystem. DNS is the world's most successful decentralized registry, and AID leverages it directly.
 - **Full Pkarr-style DHT Resolution:** We deeply admire the [Pkarr](https://pkarr.org/) project for its commitment to decentralized, censorship-resistant identity via a DHT. However, for AID's goal of creating a minimal, immediately deployable bootstrap layer, requiring clients to implement DHT lookups and interact with relays was deemed too high a barrier to entry. AID PKA uses compact Ed25519 key material but remains DNS-authority-rooted instead of key-address-rooted.
 - **DNS-First, with a Pragmatic `.well-known` Fallback**
@@ -78,7 +78,7 @@ A successful standard is defined as much by the problems it _doesn't_ solve as b
 
 ### **6. Discovery vs Identity (and PKA in v2)**
 
-PKA keeps the endpoint-proof role but uses `k` as unpadded base64url JWK `x`, derives `keyid` with RFC 7638, and no longer publishes `kid` in DNS for `aid2`.
+PKA keeps the endpoint-proof role but uses `k` as unpadded base64url JWK `x`, derives `keyid` with RFC 7638, and no longer publishes `kid` in DNS for `aid2`. The older [PKA as External Trust Anchor](https://agentcommunity.org/blog/external_identity_anchor) post explains the cross-boundary trust problem behind PKA, but it describes the legacy `aid1` wire format. Use the current specification for v2 header, key, nonce, and `keyid` behavior.
 
 Discovery answers “where and how do I connect?” Identity answers “am I really talking to who DNS pointed me to?” AID keeps these responsibilities separate by design, then offers PKA as an optional, cryptographic proof to harden discovery without changing DNS.
 

--- a/packages/docs/export-manifest.json
+++ b/packages/docs/export-manifest.json
@@ -114,13 +114,13 @@
     },
     {
       "path": "specification_v2_explained.md",
-      "bytes": 32991,
-      "sha256": "cd445ace373a5424962978c2fffc3d5308919b3df0e2a375e2263dcb66f7ea20"
+      "bytes": 33560,
+      "sha256": "e1020844ec1872d2e50660ceded5d4c4c73978716c2dfc655d33d63a4d81ee8e"
     },
     {
       "path": "specification.md",
-      "bytes": 28392,
-      "sha256": "257c5570d995033d3135fe652d81737dbf5c5851ba700a1718bfe83e663d5dc4"
+      "bytes": 28301,
+      "sha256": "9dc3e69eb9d1b8f714c72b79c85cd626060c5ec5975bb802d69e7259e051d59c"
     },
     {
       "path": "Tooling/aid_doctor.md",
@@ -154,9 +154,9 @@
     },
     {
       "path": "Understand/rationale.md",
-      "bytes": 14285,
-      "sha256": "aaf570057c083bd9d81c68205287a0d2dd1947dc777f6f596beebe42ae26c470"
+      "bytes": 14814,
+      "sha256": "599a515ee2f1c179d3538459626595141a6d18c97dbbe81f6aac836e3f540814"
     }
   ],
-  "aggregateSha256": "09242224dab1ba75035b5832650503b24c40c76f7a2d015b1daf7a0edd1d356c"
+  "aggregateSha256": "80498194c1ec4db254f5d1d57ee1d6e70e429bf0eb058dec57d248b7adaaf573"
 }

--- a/packages/docs/export-manifest.sha256
+++ b/packages/docs/export-manifest.sha256
@@ -1,1 +1,1 @@
-09242224dab1ba75035b5832650503b24c40c76f7a2d015b1daf7a0edd1d356c  export-manifest.json
+80498194c1ec4db254f5d1d57ee1d6e70e429bf0eb058dec57d248b7adaaf573  export-manifest.json

--- a/packages/docs/specification.md
+++ b/packages/docs/specification.md
@@ -340,15 +340,15 @@ If such a directory chains to DNS `k`, that chaining is the defining property of
 
 ## **6. Label Strategy**
 
-AID v2 keeps `_agent.<domain>` as the discovery label.
+AID v2 keeps `_agent.<domain>` as the discovery label for compatibility with existing deployments.
 
-The earlier RFC 8552 `_agent` registration request was rejected on procedural grounds in April 2026. That label-governance question is decoupled from the v2 PKA cleanup. A later working group or BoF process may revisit the label, but v2 does not make a label change part of the key-format work.
+Label governance is separate from the v2 key-format and endpoint-proof updates, and may be addressed by a future working group or BoF process.
 
 ---
 
 ## **7. Registries**
 
-The auth and protocol registries remain compatible with v1.2 unless changed through the normal extension process.
+The auth and protocol registries remain compatible with legacy `aid1` records unless changed through the normal extension process.
 
 ### **7.1. Auth Tokens**
 

--- a/packages/docs/specification_v2_explained.md
+++ b/packages/docs/specification_v2_explained.md
@@ -19,7 +19,14 @@ _Historical notes from the v2 specification work_
 **Editor:** Agent Community
 **Status:** Non-normative design notes
 
-> The current normative protocol is the [AID v2 specification](specification.md). This page is retained as design history and review context for the v1.2-to-v2 transition.
+> The current normative protocol is the [AID v2 specification](specification.md). This page is retained as design history and review context for the legacy `aid1` to v2 transition.
+
+## Background Reading
+
+Two earlier Agent Community posts are useful background, but the v2 specification is the implementation authority:
+
+- [PKA as External Trust Anchor](https://agentcommunity.org/blog/external_identity_anchor) explains the first-contact identity problem PKA addresses. It was written for the legacy `aid1` wire format, so use it for the trust model, not for current header, key, or `keyid` details.
+- [Why AID ships on TXT records](https://agentcommunity.org/blog/why-txt-records) explains the deployment rationale for using TXT as the mandatory baseline. AID v2 keeps that TXT baseline for the 0-th hop while leaving richer service-binding records to future profiles or adjacent discovery systems.
 
 ---
 
@@ -28,7 +35,7 @@ _Historical notes from the v2 specification work_
 This page has two layers:
 
 - **Historical specification text** uses normal normative language such as MUST, SHOULD, and MAY because it was written during the v2 review.
-- **Explainer notes** explain the reason for a design choice and how it differs from v1.2.
+- **Explainer notes** explain the reason for a design choice and how it differs from legacy `aid1`.
 
 The proposal is intentionally narrow:
 
@@ -36,9 +43,9 @@ The proposal is intentionally narrow:
 
 ---
 
-## What Changes From v1.2
+## What Changes From Legacy `aid1`
 
-| Area                   | v1.2                                 | v2                                       | Why                                                                                     |
+| Area                   | Legacy `aid1`                        | v2                                       | Why                                                                                     |
 | ---------------------- | ------------------------------------ | ---------------------------------------- | --------------------------------------------------------------------------------------- |
 | Record version         | `v=aid1`                             | `v=aid2`                                 | Clear wire-format break.                                                                |
 | PKA key encoding       | `k=z...` multibase/base58btc         | `k=<base64url>`                          | Uses the same value as the Ed25519 JWK `x` member.                                      |
@@ -362,17 +369,17 @@ If such a directory chains to DNS `k`, that chaining is the defining property of
 
 ## 6. IANA And Label Strategy
 
-The v2 design keeps `_agent.<domain>` as the discovery label.
+The v2 design keeps `_agent.<domain>` as the discovery label for compatibility with existing deployments.
 
-The earlier RFC 8552 `_agent` registration request was rejected on procedural grounds in April 2026. That label-governance question is decoupled from the v2 PKA cleanup. A later working group or BoF process may revisit the label, but this draft does not make a label change part of the key-format work.
+Label governance is separate from the v2 key-format and endpoint-proof updates, and may be addressed by a future working group or BoF process.
 
-> **Explainer:** Renaming the label while also changing key semantics would make review harder. v2 can clarify PKA without forcing the namespace question into the same decision.
+> **Explainer:** v2 can clarify PKA without forcing the namespace question into the same decision.
 
 ---
 
 ## 7. Registries
 
-The auth and protocol registries remain compatible with v1.2 unless changed through the normal extension process.
+The auth and protocol registries remain compatible with legacy `aid1` records unless changed through the normal extension process.
 
 ### Auth Tokens
 

--- a/packages/web/src/app/api/handshake/route.ts
+++ b/packages/web/src/app/api/handshake/route.ts
@@ -40,7 +40,15 @@ const getSecurityInfo = async (hostname: string): Promise<Record<string, unknown
 
     return {
       dnssec: report.dnssec.present,
-      pka: report.pka,
+      pka: {
+        present: report.pka.present,
+        attempted: report.pka.attempted,
+        verified: report.pka.verified,
+        keyid: report.pka.keyid,
+        alg: report.pka.alg,
+        createdSkewSec: report.pka.createdSkewSec,
+        covered: report.pka.covered,
+      },
       tls: report.tls,
       warnings: report.record.warnings,
       errors: report.record.errors,

--- a/packages/web/src/app/api/pka-demo/route.ts
+++ b/packages/web/src/app/api/pka-demo/route.ts
@@ -6,11 +6,9 @@ export const runtime = 'nodejs';
 // This is a DEMO key — the corresponding public key is published in the
 // _agent.pka-basic.agentcommunity.org TXT record.
 const PRIVATE_KEY_B64 = 'MC4CAQAwBQYDK2VwBCIEIH1rQ69j3HkK7wAgjeYVxHCLWlcmFwpU7XS8L2u4zG71';
-const LEGACY_KID = 'p1';
 const PUBLIC_KEY_X = 'Eesj9h7MD0cRERrc_ICXu5Lb1WkokpkbWAkRcDsxUvA';
 const KEYID = 'sYkYRKJfa8y8rCgWHb-qxqR4LY93c_hbbL10YbvT88o';
 
-const COVERED_FIELDS = ['aid-challenge', '@method', '@target-uri', 'host', 'date'];
 const V2_COVERED = '("@method";req "@target-uri";req "@authority";req "@status")';
 
 let cachedKey: CryptoKey | null = null;
@@ -36,10 +34,25 @@ function extractNonce(acceptSignature: string | null): string | null {
 export async function GET(request: Request) {
   const acceptSignature = request.headers.get('accept-signature');
   const v2Nonce = extractNonce(acceptSignature);
-  const challenge = request.headers.get('aid-challenge');
-  const date = request.headers.get('date') || new Date().toUTCString();
 
-  if (!challenge && !v2Nonce) {
+  if (!v2Nonce) {
+    if (acceptSignature || request.headers.has('aid-challenge')) {
+      return NextResponse.json(
+        {
+          error: 'AID v2 PKA requires Accept-Signature with a nonce parameter.',
+          publicKey: PUBLIC_KEY_X,
+          keyid: KEYID,
+        },
+        {
+          status: 400,
+          headers: {
+            'Cache-Control': 'no-store',
+            'Access-Control-Allow-Origin': '*',
+          },
+        },
+      );
+    }
+
     // Not a PKA handshake — return a simple JSON response describing the demo
     return NextResponse.json({
       service: 'AID PKA Demo',
@@ -54,70 +67,40 @@ export async function GET(request: Request) {
 
   const url = new URL(request.url);
   const targetUri = url.toString();
-  const host = url.host;
   const method = 'GET';
   const nowSec = Math.floor(Date.now() / 1000);
 
-  if (v2Nonce) {
-    const status = 200;
-    const expires = nowSec + 60;
-    const authority = url.port
-      ? `${url.hostname.toLowerCase()}:${url.port}`
-      : url.hostname.toLowerCase();
-    const sigInputValue = `${V2_COVERED};created=${nowSec};expires=${expires};keyid="${KEYID}";alg="ed25519";nonce="${v2Nonce}";tag="aid-pka-v2"`;
-    const lines = [
-      `"@method";req: ${method}`,
-      `"@target-uri";req: ${targetUri}`,
-      `"@authority";req: ${authority}`,
-      `"@status": ${status}`,
-      `"@signature-params": ${sigInputValue}`,
-    ];
-    const privateKey = await getPrivateKey();
-    const sig = new Uint8Array(
-      await globalThis.crypto.subtle.sign(
-        'Ed25519',
-        privateKey,
-        new TextEncoder().encode(lines.join('\n')),
-      ),
-    );
-
-    return new NextResponse(JSON.stringify({ ok: true, keyid: KEYID }), {
-      status,
-      headers: {
-        'Content-Type': 'application/json',
-        'Cache-Control': 'no-store',
-        'Signature-Input': `aid-pka=${sigInputValue}`,
-        Signature: `aid-pka=:${toBase64(sig)}:`,
-        'Access-Control-Allow-Origin': '*',
-        'Access-Control-Expose-Headers': 'Signature, Signature-Input, Cache-Control',
-      },
-    });
-  }
-
-  // Build signature base per RFC 9421
+  const status = 200;
+  const expires = nowSec + 60;
+  const authority = url.port
+    ? `${url.hostname.toLowerCase()}:${url.port}`
+    : url.hostname.toLowerCase();
+  const sigInputValue = `${V2_COVERED};created=${nowSec};expires=${expires};keyid="${KEYID}";alg="ed25519";nonce="${v2Nonce}";tag="aid-pka-v2"`;
   const lines = [
-    `"AID-Challenge": ${challenge}`,
-    `"@method": ${method}`,
-    `"@target-uri": ${targetUri}`,
-    `"host": ${host}`,
-    `"date": ${date}`,
+    `"@method";req: ${method}`,
+    `"@target-uri";req: ${targetUri}`,
+    `"@authority";req: ${authority}`,
+    `"@status": ${status}`,
+    `"@signature-params": ${sigInputValue}`,
   ];
-  const sigInputValue = `sig=("${COVERED_FIELDS.join('" "')}");created=${nowSec};keyid=${LEGACY_KID};alg="ed25519"`;
-  lines.push(`"@signature-params": ${sigInputValue}`);
-  const base = new TextEncoder().encode(lines.join('\n'));
-
   const privateKey = await getPrivateKey();
-  const sig = new Uint8Array(await globalThis.crypto.subtle.sign('Ed25519', privateKey, base));
+  const sig = new Uint8Array(
+    await globalThis.crypto.subtle.sign(
+      'Ed25519',
+      privateKey,
+      new TextEncoder().encode(lines.join('\n')),
+    ),
+  );
 
-  return new NextResponse(JSON.stringify({ ok: true, kid: LEGACY_KID }), {
-    status: 200,
+  return new NextResponse(JSON.stringify({ ok: true, keyid: KEYID }), {
+    status,
     headers: {
       'Content-Type': 'application/json',
-      Date: date,
-      'Signature-Input': sigInputValue,
-      Signature: `sig=:${toBase64(sig)}:`,
+      'Cache-Control': 'no-store',
+      'Signature-Input': `aid-pka=${sigInputValue}`,
+      Signature: `aid-pka=:${toBase64(sig)}:`,
       'Access-Control-Allow-Origin': '*',
-      'Access-Control-Expose-Headers': 'Signature, Signature-Input, Date',
+      'Access-Control-Expose-Headers': 'Signature, Signature-Input, Cache-Control',
     },
   });
 }
@@ -129,8 +112,8 @@ export function OPTIONS() {
     headers: {
       'Access-Control-Allow-Origin': '*',
       'Access-Control-Allow-Methods': 'GET, OPTIONS',
-      'Access-Control-Allow-Headers': 'AID-Challenge, Date, Accept-Signature, Cache-Control',
-      'Access-Control-Expose-Headers': 'Signature, Signature-Input, Date, Cache-Control',
+      'Access-Control-Allow-Headers': 'Accept-Signature, Cache-Control',
+      'Access-Control-Expose-Headers': 'Signature, Signature-Input, Cache-Control',
       'Access-Control-Max-Age': '86400',
     },
   });

--- a/packages/web/src/components/workbench/v11-fields/security-fields.tsx
+++ b/packages/web/src/components/workbench/v11-fields/security-fields.tsx
@@ -10,7 +10,7 @@ import { ChevronDown } from 'lucide-react';
 
 export interface SecurityFieldsProps {
   pka?: string;
-  onChange: (patch: Partial<{ pka?: string; kid?: string }>) => void;
+  onChange: (patch: Partial<{ pka?: string }>) => void;
 }
 
 export function SecurityFields({ pka, onChange }: SecurityFieldsProps) {
@@ -45,7 +45,7 @@ export function SecurityFields({ pka, onChange }: SecurityFieldsProps) {
           </Button>
         </CollapsibleTrigger>
         <CollapsibleContent className="mt-2">
-          <PkaKeyGenerator onPublicKey={(k) => onChange({ pka: k, kid: '' })} />
+          <PkaKeyGenerator onPublicKey={(k) => onChange({ pka: k })} />
         </CollapsibleContent>
       </Collapsible>
     </div>

--- a/packages/web/src/generated/examples.ts
+++ b/packages/web/src/generated/examples.ts
@@ -30,14 +30,6 @@ export const TUTORIAL_EXAMPLES: Example[] = [
     label: 'Simple',
     domain: 'simple.agentcommunity.org',
     icon: '🤖',
-    content: 'v=aid1;u=https://api.example.com/mcp;p=mcp;a=pat;s=Basic MCP Example',
-    category: 'tutorials',
-  },
-  {
-    title: 'V2 Simple',
-    label: 'V2 Simple',
-    domain: 'v2-simple.agentcommunity.org',
-    icon: '🤖',
     content: 'v=aid2;u=https://api.example.com/mcp;p=mcp;a=pat;s=Basic MCP Example',
     category: 'tutorials',
   },
@@ -45,14 +37,6 @@ export const TUTORIAL_EXAMPLES: Example[] = [
     title: 'Local Docker',
     label: 'Local Docker',
     domain: 'local-docker.agentcommunity.org',
-    icon: '🐳',
-    content: 'v=aid1;u=docker:myimage;p=local;s=Local Docker Agent',
-    category: 'tutorials',
-  },
-  {
-    title: 'V2 Local Docker',
-    label: 'V2 Local Docker',
-    domain: 'v2-local-docker.agentcommunity.org',
     icon: '🐳',
     content: 'v=aid2;u=docker:myimage;p=local;s=Local Docker Agent',
     category: 'tutorials',
@@ -62,14 +46,6 @@ export const TUTORIAL_EXAMPLES: Example[] = [
     label: 'Messy',
     domain: 'messy.agentcommunity.org',
     icon: '🧹',
-    content: ' v=aid1 ; u=https://api.example.com/mcp ; p=mcp ; extra=ignored ',
-    category: 'tutorials',
-  },
-  {
-    title: 'V2 Messy',
-    label: 'V2 Messy',
-    domain: 'v2-messy.agentcommunity.org',
-    icon: '🧹',
     content: ' v=aid2 ; u=https://api.example.com/mcp ; p=mcp ; extra=ignored ',
     category: 'tutorials',
   },
@@ -77,14 +53,6 @@ export const TUTORIAL_EXAMPLES: Example[] = [
     title: 'Multi String',
     label: 'Multi String',
     domain: 'multi-string.agentcommunity.org',
-    icon: '📄',
-    content: 'v=aid1;u=https://api.example.com/mcp;p=mcp;s=Multi string part 1',
-    category: 'tutorials',
-  },
-  {
-    title: 'V2 Multi String',
-    label: 'V2 Multi String',
-    domain: 'v2-multi-string.agentcommunity.org',
     icon: '📄',
     content: 'v=aid2;u=https://api.example.com/mcp;p=mcp;s=Multi string part 1',
     category: 'tutorials',
@@ -95,15 +63,6 @@ export const TUTORIAL_EXAMPLES: Example[] = [
     domain: 'pka-basic.agentcommunity.org',
     icon: '🔐',
     content:
-      'v=aid1;p=mcp;u=https://aid.agentcommunity.org/api/pka-demo;k=z2Cwtdw9EZzy1Mhv8ZmGRoMJPkJcU3amQQhpUJx35pKUs;i=p1;s=Live PKA Demo',
-    category: 'tutorials',
-  },
-  {
-    title: 'V2 Pka Basic',
-    label: 'V2 Pka Basic',
-    domain: 'v2-pka-basic.agentcommunity.org',
-    icon: '🔐',
-    content:
       'v=aid2;p=mcp;u=https://aid.agentcommunity.org/api/pka-demo;k=Eesj9h7MD0cRERrc_ICXu5Lb1WkokpkbWAkRcDsxUvA;s=Live PKA Demo',
     category: 'tutorials',
   },
@@ -111,18 +70,9 @@ export const TUTORIAL_EXAMPLES: Example[] = [
 
 export const REFERENCE_EXAMPLES: Example[] = [
   {
-    title: 'Complete V1 2',
-    label: 'Complete V1 2',
+    title: 'Complete',
+    label: 'Complete',
     domain: 'complete.agentcommunity.org',
-    icon: '✨',
-    content:
-      'v=aid1;p=mcp;u=https://api.complete.agentcommunity.org/mcp;d=https://docs.agentcommunity.org/complete;e=2026-12-31T23:59:59Z;s=Complete v1.2 with all features',
-    category: 'reference',
-  },
-  {
-    title: 'V2 Complete',
-    label: 'V2 Complete',
-    domain: 'v2-complete.agentcommunity.org',
     icon: '✨',
     content:
       'v=aid2;p=mcp;u=https://api.complete.agentcommunity.org/mcp;d=https://docs.agentcommunity.org/complete;e=2026-12-31T23:59:59Z;s=Complete v2 with all features',
@@ -132,15 +82,6 @@ export const REFERENCE_EXAMPLES: Example[] = [
     title: 'Secure',
     label: 'Secure',
     domain: 'secure.agentcommunity.org',
-    icon: '🔒',
-    content:
-      'v=aid1;u=https://api.secure.agentcommunity.org/mcp;p=mcp;a=pat;d=https://docs.agentcommunity.org/secure;s=Secure MCP with Auth',
-    category: 'reference',
-  },
-  {
-    title: 'V2 Secure',
-    label: 'V2 Secure',
-    domain: 'v2-secure.agentcommunity.org',
     icon: '🔒',
     content:
       'v=aid2;u=https://api.secure.agentcommunity.org/mcp;p=mcp;a=pat;d=https://docs.agentcommunity.org/secure;s=Secure MCP with Auth',
@@ -155,15 +96,6 @@ export const REAL_WORLD_EXAMPLES: Example[] = [
     domain: 'supabase.agentcommunity.org',
     icon: '/icons/supabase.svg',
     content:
-      'v=aid1;u=https://api.supabase.com/mcp;p=mcp;a=pat;d=https://supabase.com/docs/guides/getting-started/mcp;s=Supabase MCP (Mock Service)',
-    category: 'real_world',
-  },
-  {
-    title: 'V2 Supabase',
-    label: 'V2 Supabase',
-    domain: 'v2-supabase.agentcommunity.org',
-    icon: '/icons/supabase.svg',
-    content:
       'v=aid2;u=https://api.supabase.com/mcp;p=mcp;a=pat;d=https://supabase.com/docs/guides/getting-started/mcp;s=Supabase MCP (Mock Service)',
     category: 'real_world',
   },
@@ -171,15 +103,6 @@ export const REAL_WORLD_EXAMPLES: Example[] = [
     title: 'Auth0',
     label: 'Auth0',
     domain: 'auth0.agentcommunity.org',
-    icon: '/icons/auth0.svg',
-    content:
-      'v=aid1;u=https://ai.auth0.com/mcp;p=mcp;a=pat;d=https://auth0.com/docs/get-started/auth0-mcp-server;s=Auth0 MCP (Mock Service)',
-    category: 'real_world',
-  },
-  {
-    title: 'V2 Auth0',
-    label: 'V2 Auth0',
-    domain: 'v2-auth0.agentcommunity.org',
     icon: '/icons/auth0.svg',
     content:
       'v=aid2;u=https://ai.auth0.com/mcp;p=mcp;a=pat;d=https://auth0.com/docs/get-started/auth0-mcp-server;s=Auth0 MCP (Mock Service)',
@@ -191,15 +114,6 @@ export const REAL_WORLD_EXAMPLES: Example[] = [
     domain: 'firecrawl.agentcommunity.org',
     icon: '🔥',
     content:
-      'v=aid1;u=npx:firecrawl-mcp;p=local;d=https://docs.firecrawl.dev/mcp-server;s=Firecrawl Web Scraping Agent',
-    category: 'real_world',
-  },
-  {
-    title: 'V2 Firecrawl',
-    label: 'V2 Firecrawl',
-    domain: 'v2-firecrawl.agentcommunity.org',
-    icon: '🔥',
-    content:
       'v=aid2;u=npx:firecrawl-mcp;p=local;d=https://docs.firecrawl.dev/mcp-server;s=Firecrawl Web Scraping Agent',
     category: 'real_world',
   },
@@ -207,15 +121,6 @@ export const REAL_WORLD_EXAMPLES: Example[] = [
     title: 'Playwright',
     label: 'Playwright',
     domain: 'playwright.agentcommunity.org',
-    icon: '/icons/playwright.svg',
-    content:
-      'v=aid1;u=https://api.playwright.dev;p=openapi;d=https://github.com/microsoft/playwright-mcp;s=Playwright OpenAPI (Mock Service)',
-    category: 'real_world',
-  },
-  {
-    title: 'V2 Playwright',
-    label: 'V2 Playwright',
-    domain: 'v2-playwright.agentcommunity.org',
     icon: '/icons/playwright.svg',
     content:
       'v=aid2;u=https://api.playwright.dev;p=openapi;d=https://github.com/microsoft/playwright-mcp;s=Playwright OpenAPI (Mock Service)',
@@ -230,15 +135,6 @@ export const PROTOCOL_EXAMPLES: Example[] = [
     domain: 'a2a.agentcommunity.org',
     icon: '🤝',
     content:
-      'v=aid1;u=https://a2a.agentcommunity.org/.well-known/agent.json;p=a2a;d=https://a2aprotocol.ai/;s=A2A Protocol Showcase',
-    category: 'protocols',
-  },
-  {
-    title: 'V2 A2a Showcase',
-    label: 'V2 A2a Showcase',
-    domain: 'v2-a2a.agentcommunity.org',
-    icon: '🤝',
-    content:
       'v=aid2;u=https://a2a.agentcommunity.org/.well-known/agent.json;p=a2a;d=https://a2aprotocol.ai/;s=A2A Protocol Showcase',
     category: 'protocols',
   },
@@ -246,15 +142,6 @@ export const PROTOCOL_EXAMPLES: Example[] = [
     title: 'Ucp Showcase',
     label: 'Ucp Showcase',
     domain: 'ucp.agentcommunity.org',
-    icon: '🛒',
-    content:
-      'v=aid1;u=https://ucp.agentcommunity.org/ucp;p=ucp;d=https://www.universalcommerce.io/;s=UCP Commerce Showcase',
-    category: 'protocols',
-  },
-  {
-    title: 'V2 Ucp Showcase',
-    label: 'V2 Ucp Showcase',
-    domain: 'v2-ucp.agentcommunity.org',
     icon: '🛒',
     content:
       'v=aid2;u=https://ucp.agentcommunity.org/ucp;p=ucp;d=https://www.universalcommerce.io/;s=UCP Commerce Showcase',
@@ -266,15 +153,6 @@ export const PROTOCOL_EXAMPLES: Example[] = [
     domain: 'graphql.agentcommunity.org',
     icon: '◇',
     content:
-      'v=aid1;u=https://graphql.agentcommunity.org/graphql;p=graphql;d=https://graphql.org/;s=GraphQL Agent Showcase',
-    category: 'protocols',
-  },
-  {
-    title: 'V2 Graphql Showcase',
-    label: 'V2 Graphql Showcase',
-    domain: 'v2-graphql.agentcommunity.org',
-    icon: '◇',
-    content:
       'v=aid2;u=https://graphql.agentcommunity.org/graphql;p=graphql;d=https://graphql.org/;s=GraphQL Agent Showcase',
     category: 'protocols',
   },
@@ -282,15 +160,6 @@ export const PROTOCOL_EXAMPLES: Example[] = [
     title: 'Grpc Showcase',
     label: 'Grpc Showcase',
     domain: 'grpc.agentcommunity.org',
-    icon: '⚡',
-    content:
-      'v=aid1;u=https://grpc.agentcommunity.org;p=grpc;d=https://grpc.io/;s=gRPC Agent Showcase',
-    category: 'protocols',
-  },
-  {
-    title: 'V2 Grpc Showcase',
-    label: 'V2 Grpc Showcase',
-    domain: 'v2-grpc.agentcommunity.org',
     icon: '⚡',
     content:
       'v=aid2;u=https://grpc.agentcommunity.org;p=grpc;d=https://grpc.io/;s=gRPC Agent Showcase',
@@ -304,14 +173,6 @@ export const OTHER_CHAT_EXAMPLES: Example[] = [
     label: 'No Server',
     domain: 'no-server.agentcommunity.org',
     icon: '❌',
-    content: 'v=aid1;u=https://does-not-exist.agentcommunity.org:1234;p=mcp;s=Offline Agent',
-    category: 'error_cases',
-  },
-  {
-    title: 'V2 No Server',
-    label: 'V2 No Server',
-    domain: 'v2-no-server.agentcommunity.org',
-    icon: '❌',
     content: 'v=aid2;u=https://does-not-exist.agentcommunity.org:1234;p=mcp;s=Offline Agent',
     category: 'error_cases',
   },
@@ -319,15 +180,6 @@ export const OTHER_CHAT_EXAMPLES: Example[] = [
     title: 'Deprecated',
     label: 'Deprecated',
     domain: 'deprecated.agentcommunity.org',
-    icon: '⚠️',
-    content:
-      'v=aid1;u=https://api.deprecated.agentcommunity.org/mcp;p=mcp;a=pat;e=2025-12-31T23:59:59Z;d=https://docs.agentcommunity.org/migration;s=Deprecated - migrate soon',
-    category: 'error_cases',
-  },
-  {
-    title: 'V2 Deprecated',
-    label: 'V2 Deprecated',
-    domain: 'v2-deprecated.agentcommunity.org',
     icon: '⚠️',
     content:
       'v=aid2;u=https://api.deprecated.agentcommunity.org/mcp;p=mcp;a=pat;e=2025-12-31T23:59:59Z;d=https://docs.agentcommunity.org/migration;s=Deprecated - migrate soon',

--- a/packages/web/src/hooks/chat-engine/signals.ts
+++ b/packages/web/src/hooks/chat-engine/signals.ts
@@ -118,7 +118,7 @@ function discoveryErrorHints(domain: string, code?: string): { title: string; hi
         title: 'Discovery blocked by security checks',
         hints: [
           'Check DNS/network access and public resolver reachability.',
-          'If pka is present, verify handshake headers and key rotation data.',
+          'If pka is present, verify the derived keyid and AID v2 handshake headers.',
           'Inspect TLS and redirect behavior on fallback endpoints.',
         ],
       };
@@ -263,6 +263,9 @@ export function buildDiscoveryResultSignal(domain: string, result: DiscoveryResu
       value: formatPkaStatus(metadata.pka),
       tone: metadata.pka.verified === false ? 'error' : 'default',
     });
+    if (metadata.pka.keyid) {
+      details.push({ label: 'PKA keyid', value: metadata.pka.keyid });
+    }
   }
   if (metadata.tls) {
     details.push({
@@ -366,6 +369,9 @@ export function buildConnectionResultSignal(
         value: formatPkaStatus(security.pka),
         tone: security.pka.verified === false ? 'error' : 'default',
       });
+      if (security.pka.keyid) {
+        details.push({ label: 'PKA keyid', value: security.pka.keyid });
+      }
     }
     if (security?.tls) {
       details.push({

--- a/packages/web/src/hooks/use-connection.ts
+++ b/packages/web/src/hooks/use-connection.ts
@@ -33,7 +33,7 @@ export interface HandshakeSuccessData {
   agentCard?: AgentCard;
   security?: {
     dnssec?: boolean;
-    pka?: { present: boolean; attempted: boolean; verified: boolean | null; kid: string | null };
+    pka?: { present: boolean; attempted: boolean; verified: boolean | null; keyid: string | null };
     tls?: { checked: boolean; valid: boolean | null; daysRemaining: number | null };
     warnings?: Array<{ code: string; message: string }>;
     errors?: Array<{ code: string; message: string }>;

--- a/packages/web/src/hooks/use-discovery.ts
+++ b/packages/web/src/hooks/use-discovery.ts
@@ -27,7 +27,7 @@ export interface DiscoveryMetadata {
   source: 'DNS-over-HTTPS' | 'DNS';
   txtRecord?: string;
   dnssecPresent?: boolean;
-  pka?: { present: boolean; verified: boolean | null; kid: string | null };
+  pka?: { present: boolean; verified: boolean | null; keyid: string | null };
   tls?: { valid: boolean | null; daysRemaining: number | null };
 }
 
@@ -37,6 +37,28 @@ export type DiscoveryResult = Result<{ record: DiscoveryData; metadata: Discover
 // TEMPORARY backward-compat alias so that legacy imports compile during migration.
 // FIXME: remove after all call-sites adopt Result pattern.
 export type LegacyDiscoveryResult = DiscoveryResult;
+
+const toBase64Url = (bytes: Uint8Array): string => {
+  let binary = '';
+  for (const byte of bytes) {
+    binary += String.fromCodePoint(byte);
+  }
+  return btoa(binary).replaceAll('+', '-').replaceAll('/', '_').replaceAll('=', '');
+};
+
+const deriveAid2Keyid = async (pka: string): Promise<string | null> => {
+  if (!globalThis.crypto?.subtle) return null;
+  try {
+    const input = `{"crv":"Ed25519","kty":"OKP","x":"${pka}"}`;
+    const digest = await globalThis.crypto.subtle.digest(
+      'SHA-256',
+      new TextEncoder().encode(input),
+    );
+    return toBase64Url(new Uint8Array(digest));
+  } catch {
+    return null;
+  }
+};
 
 /**
  * React hook for performing client-side AID DNS discovery.
@@ -59,6 +81,11 @@ export function useDiscovery() {
       const reconstructedTxt = Object.entries(libResult.record)
         .map(([k, v]) => `${k}=${v as string}`)
         .join(';');
+      const pkaKeyid = parsed.pka
+        ? (parsed.v === 'aid2'
+          ? await deriveAid2Keyid(parsed.pka)
+          : (parsed.kid ?? null))
+        : null;
 
       // Format the successful result into the shape our UI expects
       const successResult: DiscoveryResult = {
@@ -79,7 +106,7 @@ export function useDiscovery() {
               ? {
                   present: true,
                   verified: null,
-                  kid: parsed.v === 'aid1' ? (parsed.kid ?? null) : null,
+                  keyid: pkaKeyid,
                 }
               : undefined,
           },

--- a/packages/web/src/hooks/use-generator-form.ts
+++ b/packages/web/src/hooks/use-generator-form.ts
@@ -31,7 +31,6 @@ const defaultFormData: GeneratorFormData = {
   docs: '',
   dep: '',
   pka: '',
-  kid: '',
 };
 
 export function useGeneratorForm() {
@@ -127,7 +126,6 @@ export function useGeneratorForm() {
       docs: parsed.docs ?? previous.docs,
       dep: parsed.dep ?? previous.dep,
       pka: parsed.pka ?? previous.pka,
-      kid: parsed.kid ?? previous.kid,
     }));
   };
 

--- a/packages/web/src/lib/aid-generator.ts
+++ b/packages/web/src/lib/aid-generator.ts
@@ -17,7 +17,6 @@ export interface AidGeneratorData {
   docs?: string;
   dep?: string; // ISO timestamp
   pka?: string;
-  kid?: string;
 }
 
 // The core logic function
@@ -43,13 +42,10 @@ export function validateTxt(record: string): { isValid: boolean; error?: string 
     const v = map.get('v') ?? map.get('version');
     const uri = map.get('u') ?? map.get('uri');
     const proto = map.get('p') ?? map.get('proto');
-    if (v !== 'aid1' && v !== 'aid2') throw new Error('Missing or invalid version');
+    if (v !== 'aid2') throw new Error('Missing or invalid version');
     if (!uri) throw new Error('Missing uri/u');
     if (!proto) throw new Error('Missing proto/p');
-    if (v === 'aid2' && (map.get('i') || map.get('kid')))
-      throw new Error('kid is not valid in aid2');
-    if (v === 'aid1' && (map.get('k') || map.get('pka')) && !map.get('i') && !map.get('kid'))
-      throw new Error('kid requires pka');
+    if (map.get('i') || map.get('kid')) throw new Error('kid is not valid in aid2');
     return { isValid: true };
   } catch (error) {
     return { isValid: false, error: error instanceof Error ? error.message : 'Invalid' };

--- a/packages/web/src/lib/api/generator-validation.ts
+++ b/packages/web/src/lib/api/generator-validation.ts
@@ -180,7 +180,6 @@ export const validateGeneratorPayload = (payload: unknown): GeneratorValidationR
       docs: data.docs,
       dep: data.dep,
       pka: data.pka,
-      kid: data.kid,
     };
     txt = buildTxtRecordVariant(engineData, true);
     txtBytes = safeByteLength(txt);

--- a/packages/web/src/lib/generator/core.ts
+++ b/packages/web/src/lib/generator/core.ts
@@ -123,8 +123,6 @@ export function parseRecordString(str: string): Partial<AidGeneratorFormData> {
   if (dep) out.dep = dep;
   const pka = get('k', 'pka');
   if (pka) out.pka = pka;
-  const kid = get('i', 'kid');
-  if (kid) out.kid = kid;
   return out;
 }
 

--- a/packages/web/src/lib/generator/types.ts
+++ b/packages/web/src/lib/generator/types.ts
@@ -7,7 +7,6 @@ export interface AidGeneratorFormData {
   docs?: string;
   dep?: string;
   pka?: string;
-  kid?: string;
 }
 
 export interface ValidationIssue {
@@ -20,5 +19,3 @@ export interface ValidationResult {
   errors: ValidationIssue[];
   warnings: ValidationIssue[];
 }
-
-

--- a/packages/web/src/lib/protocols/types.ts
+++ b/packages/web/src/lib/protocols/types.ts
@@ -3,7 +3,6 @@ import type { ProtocolGuidance } from '@/hooks/use-connection';
 
 // Re-export for use by protocol handlers
 
-
 /**
  * Agent Card structure per A2A specification
  */
@@ -29,7 +28,12 @@ export interface ProtocolResult {
     capabilities: Array<{ id: string; type: 'tool' | 'resource' }>;
     security?: {
       dnssec?: boolean;
-      pka?: { present: boolean; attempted: boolean; verified: boolean | null; kid: string | null };
+      pka?: {
+        present: boolean;
+        attempted: boolean;
+        verified: boolean | null;
+        keyid: string | null;
+      };
       tls?: { checked: boolean; valid: boolean | null; daysRemaining: number | null };
       warnings?: Array<{ code: string; message: string }>;
       errors?: Array<{ code: string; message: string }>;
@@ -42,7 +46,7 @@ export interface ProtocolResult {
   // Security info (available for all protocols)
   security?: {
     dnssec?: boolean;
-    pka?: { present: boolean; attempted: boolean; verified: boolean | null; kid: string | null };
+    pka?: { present: boolean; attempted: boolean; verified: boolean | null; keyid: string | null };
     tls?: { checked: boolean; valid: boolean | null; daysRemaining: number | null };
     warnings?: Array<{ code: string; message: string }>;
     errors?: Array<{ code: string; message: string }>;
@@ -80,5 +84,5 @@ export interface ProtocolHandler {
   handle(options: ProtocolHandlerOptions): Promise<ProtocolResult>;
 }
 
-export {type ProtocolToken} from '@/lib/datasources/types';
-export {type ProtocolGuidance} from '@/hooks/use-connection';
+export { type ProtocolToken } from '@/lib/datasources/types';
+export { type ProtocolGuidance } from '@/hooks/use-connection';

--- a/packages/web/src/lib/scenarios/index.ts
+++ b/packages/web/src/lib/scenarios/index.ts
@@ -40,11 +40,11 @@ export const scenarios: Record<string, ScenarioManifest> = {
       ok: true,
       value: {
         record: {
-          v: 'aid1',
-          uri: 'tcp://messy.agentcommunity.org:9999/weird-path',
+          v: 'aid2',
+          uri: 'https://messy.agentcommunity.org/mcp',
           proto: 'mcp',
           host: 'messy.agentcommunity.org',
-          port: 9999,
+          port: 443,
           desc: 'Chaotic experimental agent',
         } as unknown as import('@/hooks/use-discovery').DiscoveryData,
         metadata: {
@@ -52,6 +52,8 @@ export const scenarios: Record<string, ScenarioManifest> = {
           lookupTime: 100,
           recordType: 'TXT',
           source: 'DNS',
+          txtRecord:
+            ' v=aid2 ; u=https://messy.agentcommunity.org/mcp ; p=mcp ; s=Chaotic experimental agent ',
         },
       },
     },
@@ -79,11 +81,11 @@ export const scenarios: Record<string, ScenarioManifest> = {
       ok: true,
       value: {
         record: {
-          v: 'aid1',
-          uri: 'https://api.firecrawl.dev',
-          proto: 'a2a',
-          host: 'api.firecrawl.dev',
-          port: 443,
+          v: 'aid2',
+          uri: 'npx:firecrawl-mcp',
+          proto: 'local',
+          host: 'firecrawl-mcp',
+          port: 0,
           desc: 'Firecrawl Agent',
         } as unknown as import('@/hooks/use-discovery').DiscoveryData,
         metadata: {
@@ -91,6 +93,8 @@ export const scenarios: Record<string, ScenarioManifest> = {
           lookupTime: 50,
           recordType: 'TXT',
           source: 'DNS',
+          txtRecord:
+            'v=aid2;u=npx:firecrawl-mcp;p=local;d=https://docs.firecrawl.dev/mcp-server;s=Firecrawl Agent',
         },
       },
     },
@@ -116,7 +120,7 @@ export const scenarios: Record<string, ScenarioManifest> = {
       ok: true,
       value: {
         record: {
-          v: 'aid1',
+          v: 'aid2',
           uri: 'https://api.playwright.dev/mcp',
           proto: 'openapi',
           host: 'api.playwright.dev',
@@ -128,6 +132,8 @@ export const scenarios: Record<string, ScenarioManifest> = {
           lookupTime: 60,
           recordType: 'TXT',
           source: 'DNS',
+          txtRecord:
+            'v=aid2;u=https://api.playwright.dev/mcp;p=openapi;d=https://github.com/microsoft/playwright-mcp;s=Playwright Agent',
         },
       },
     },
@@ -153,10 +159,10 @@ export const scenarios: Record<string, ScenarioManifest> = {
       ok: true,
       value: {
         record: {
-          v: 'aid1',
-          uri: 'wss://multi.string.com/api',
+          v: 'aid2',
+          uri: 'https://multi-string.agentcommunity.org/mcp',
           proto: 'mcp',
-          host: 'multi.string.com',
+          host: 'multi-string.agentcommunity.org',
           port: 443,
           desc: 'Agent from multiple TXT records',
         } as unknown as import('@/hooks/use-discovery').DiscoveryData,
@@ -165,6 +171,8 @@ export const scenarios: Record<string, ScenarioManifest> = {
           lookupTime: 140,
           recordType: 'TXT',
           source: 'DNS',
+          txtRecord:
+            'v=aid2;u=https://multi-string.agentcommunity.org/mcp;p=mcp;s=Agent from multiple TXT records',
         },
       },
     },
@@ -189,7 +197,7 @@ export const scenarios: Record<string, ScenarioManifest> = {
       ok: true,
       value: {
         record: {
-          v: 'aid1',
+          v: 'aid2',
           uri: 'https://does-not-exist.agentcommunity.org:1234',
           proto: 'mcp',
           host: 'does-not-exist.agentcommunity.org',
@@ -201,6 +209,8 @@ export const scenarios: Record<string, ScenarioManifest> = {
           lookupTime: 95,
           recordType: 'TXT',
           source: 'DNS',
+          txtRecord:
+            'v=aid2;u=https://does-not-exist.agentcommunity.org:1234;p=mcp;s=Offline Agent',
         },
       },
     },

--- a/packages/web/src/tests/chat-engine-signals.test.ts
+++ b/packages/web/src/tests/chat-engine-signals.test.ts
@@ -11,7 +11,7 @@ const discoveryOk = (): DiscoveryResult => ({
   ok: true,
   value: {
     record: {
-      v: 'aid1',
+      v: 'aid2',
       uri: 'https://api.example.com/mcp',
       proto: 'mcp',
       auth: 'pat',
@@ -41,6 +41,25 @@ describe('chat-engine signal builders', () => {
     expect(signal.status).toBe('success');
     expect(signal.title).toContain('AID resolver');
     expect(signal.details?.some((d) => d.label === 'Protocol' && d.value === 'mcp')).toBe(true);
+  });
+
+  it('includes derived PKA keyid in discovery details', () => {
+    const result = discoveryOk();
+    if (!result.ok) throw new Error('Expected successful discovery fixture');
+    result.value.metadata.pka = {
+      present: true,
+      verified: null,
+      keyid: 'sYkYRKJfa8y8rCgWHb-qxqR4LY93c_hbbL10YbvT88o',
+    };
+
+    const signal = buildDiscoveryResultSignal('example.com', result);
+    expect(
+      signal.details?.some(
+        (detail) =>
+          detail.label === 'PKA keyid' &&
+          detail.value === 'sYkYRKJfa8y8rCgWHb-qxqR4LY93c_hbbL10YbvT88o',
+      ),
+    ).toBe(true);
   });
 
   it('maps ERR_NO_RECORD to discovery guidance', () => {

--- a/packages/web/src/tests/pka-demo-route.test.ts
+++ b/packages/web/src/tests/pka-demo-route.test.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'node:crypto';
+import { createHash, createPublicKey, verify as verifySignature } from 'node:crypto';
 import { describe, expect, it } from 'vitest';
 import { GET, OPTIONS } from '@/app/api/pka-demo/route';
 
@@ -11,9 +11,6 @@ const decodeSignatureHeader = (value: string): Uint8Array => {
   if (!encoded) throw new Error(`Invalid Signature header: ${value}`);
   return new Uint8Array(Buffer.from(encoded, 'base64'));
 };
-
-const toArrayBuffer = (bytes: Uint8Array): ArrayBuffer =>
-  bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
 
 const toBase64Url = (bytes: Uint8Array): string =>
   Buffer.from(bytes).toString('base64url').replaceAll('=', '');
@@ -66,22 +63,18 @@ describe('/api/pka-demo', () => {
       '"@status": 200',
       `"@signature-params": ${signatureParams}`,
     ].join('\n');
-    const key = await globalThis.crypto.subtle.importKey(
-      'jwk',
-      { kty: 'OKP', crv: 'Ed25519', x: info.publicKey },
-      { name: 'Ed25519' },
-      false,
-      ['verify'],
-    );
-
-    await expect(
-      globalThis.crypto.subtle.verify(
-        'Ed25519',
+    const key = createPublicKey({
+      key: { kty: 'OKP', crv: 'Ed25519', x: info.publicKey },
+      format: 'jwk',
+    });
+    expect(
+      verifySignature(
+        null,
+        Buffer.from(signatureBase, 'utf8'),
         key,
-        toArrayBuffer(decodeSignatureHeader(signature)),
-        new TextEncoder().encode(signatureBase),
+        Buffer.from(decodeSignatureHeader(signature)),
       ),
-    ).resolves.toBe(true);
+    ).toBe(true);
   });
 
   it('does not accept the legacy AID-Challenge handshake path', async () => {

--- a/packages/web/src/tests/pka-demo-route.test.ts
+++ b/packages/web/src/tests/pka-demo-route.test.ts
@@ -1,0 +1,109 @@
+import { createHash } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import { GET, OPTIONS } from '@/app/api/pka-demo/route';
+
+const PKA_DEMO_URL = 'https://aid.agentcommunity.org/api/pka-demo';
+const ACCEPT_SIGNATURE =
+  'aid-pka=("@method";req "@target-uri";req "@authority";req "@status");created;expires;keyid="sYkYRKJfa8y8rCgWHb-qxqR4LY93c_hbbL10YbvT88o";alg="ed25519";nonce="test-nonce-123";tag="aid-pka-v2"';
+
+const decodeSignatureHeader = (value: string): Uint8Array => {
+  const encoded = value.match(/^aid-pka=:(.+):$/)?.[1];
+  if (!encoded) throw new Error(`Invalid Signature header: ${value}`);
+  return new Uint8Array(Buffer.from(encoded, 'base64'));
+};
+
+const toArrayBuffer = (bytes: Uint8Array): ArrayBuffer =>
+  bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
+
+const toBase64Url = (bytes: Uint8Array): string =>
+  Buffer.from(bytes).toString('base64url').replaceAll('=', '');
+
+const jwkThumbprint = (x: string): string =>
+  createHash('sha256')
+    .update(JSON.stringify({ crv: 'Ed25519', kty: 'OKP', x }))
+    .digest('base64url');
+
+describe('/api/pka-demo', () => {
+  it('advertises a v2 public key whose keyid is the RFC7638 thumbprint', async () => {
+    const response = await GET(new Request(PKA_DEMO_URL));
+    const body = (await response.json()) as { publicKey: string; keyid: string };
+
+    expect(response.status).toBe(200);
+    expect(body.publicKey).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(Buffer.from(body.publicKey, 'base64url')).toHaveLength(32);
+    expect(body.keyid).toBe(jwkThumbprint(body.publicKey));
+  });
+
+  it('returns a nonce-bound RFC 9421 response signature for AID v2 PKA', async () => {
+    const infoResponse = await GET(new Request(PKA_DEMO_URL));
+    const info = (await infoResponse.json()) as { publicKey: string };
+
+    const response = await GET(
+      new Request(PKA_DEMO_URL, {
+        headers: { 'Accept-Signature': ACCEPT_SIGNATURE },
+      }),
+    );
+    const body = (await response.json()) as { keyid: string };
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Cache-Control')).toBe('no-store');
+    expect(body.keyid).toBe(jwkThumbprint(info.publicKey));
+
+    const signatureInput = response.headers.get('Signature-Input');
+    const signature = response.headers.get('Signature');
+    expect(signatureInput).toContain('aid-pka=');
+    expect(signatureInput).toContain('nonce="test-nonce-123"');
+    expect(signatureInput).toContain('tag="aid-pka-v2"');
+    expect(signature).toMatch(/^aid-pka=:.+:$/);
+
+    const signatureParams = signatureInput?.replace(/^aid-pka=/, '');
+    if (!signatureParams || !signature) throw new Error('Missing signature headers');
+
+    const signatureBase = [
+      '"@method";req: GET',
+      `"@target-uri";req: ${PKA_DEMO_URL}`,
+      '"@authority";req: aid.agentcommunity.org',
+      '"@status": 200',
+      `"@signature-params": ${signatureParams}`,
+    ].join('\n');
+    const key = await globalThis.crypto.subtle.importKey(
+      'jwk',
+      { kty: 'OKP', crv: 'Ed25519', x: info.publicKey },
+      { name: 'Ed25519' },
+      false,
+      ['verify'],
+    );
+
+    await expect(
+      globalThis.crypto.subtle.verify(
+        'Ed25519',
+        key,
+        toArrayBuffer(decodeSignatureHeader(signature)),
+        new TextEncoder().encode(signatureBase),
+      ),
+    ).resolves.toBe(true);
+  });
+
+  it('does not accept the legacy AID-Challenge handshake path', async () => {
+    const response = await GET(
+      new Request(PKA_DEMO_URL, {
+        headers: { 'AID-Challenge': toBase64Url(new Uint8Array(32).fill(1)) },
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(response.headers.get('Signature-Input')).toBeNull();
+    expect(response.headers.get('Signature')).toBeNull();
+  });
+
+  it('preflights only the v2 PKA request headers', () => {
+    const response = OPTIONS();
+
+    expect(response.headers.get('Access-Control-Allow-Headers')).toBe(
+      'Accept-Signature, Cache-Control',
+    );
+    expect(response.headers.get('Access-Control-Expose-Headers')).toBe(
+      'Signature, Signature-Input, Cache-Control',
+    );
+  });
+});

--- a/packages/web/src/tests/web-v2-surface.test.ts
+++ b/packages/web/src/tests/web-v2-surface.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import {
+  OTHER_CHAT_EXAMPLES,
+  PROTOCOL_EXAMPLES,
+  REAL_WORLD_EXAMPLES,
+  REFERENCE_EXAMPLES,
+  TUTORIAL_EXAMPLES,
+  type Example,
+} from '@/generated/examples';
+import { scenarios } from '@/lib/scenarios';
+import { buildTxtRecord, parseRecordString } from '@/lib/generator/core';
+
+const allExamples: Example[] = [
+  ...TUTORIAL_EXAMPLES,
+  ...REFERENCE_EXAMPLES,
+  ...REAL_WORLD_EXAMPLES,
+  ...PROTOCOL_EXAMPLES,
+  ...OTHER_CHAT_EXAMPLES,
+];
+
+const parseFields = (record: string): Map<string, string> =>
+  new Map(
+    record
+      .split(';')
+      .map((part) => part.trim())
+      .filter(Boolean)
+      .map((part) => {
+        const separator = part.indexOf('=');
+        return [part.slice(0, separator).trim().toLowerCase(), part.slice(separator + 1).trim()];
+      }),
+  );
+
+describe('web AID v2 surface', () => {
+  it('ships only aid2 generated examples without legacy key identifiers', () => {
+    expect(allExamples.length).toBeGreaterThan(0);
+
+    for (const example of allExamples) {
+      const fields = parseFields(example.content);
+      expect(fields.get('v'), example.domain).toBe('aid2');
+      expect(fields.has('i'), example.domain).toBe(false);
+      expect(fields.has('kid'), example.domain).toBe(false);
+      expect(example.domain.startsWith('v2-'), example.domain).toBe(false);
+    }
+  });
+
+  it('uses aid2 records in built-in resolver scenarios', () => {
+    for (const [domain, scenario] of Object.entries(scenarios)) {
+      const discovery = scenario.discovery as
+        | {
+            ok: true;
+            value: {
+              record: { v?: string };
+              metadata?: { txtRecord?: string };
+            };
+          }
+        | { ok: false }
+        | undefined;
+
+      if (!discovery || discovery.ok === false) continue;
+
+      expect(discovery.value.record.v, domain).toBe('aid2');
+      if (discovery.value.metadata?.txtRecord) {
+        const fields = parseFields(discovery.value.metadata.txtRecord);
+        expect(fields.get('v'), domain).toBe('aid2');
+        expect(fields.has('i'), domain).toBe(false);
+        expect(fields.has('kid'), domain).toBe(false);
+      }
+    }
+  });
+
+  it('does not rehydrate legacy kid/i into creator state or TXT output', () => {
+    const parsed = parseRecordString(
+      'v=aid2;u=https://api.example.com/mcp;p=mcp;k=ebVWLo_mVPlAeLES6KmLp5AfhTrmlb7X4OORC60ElmQ;i=legacy;kid=legacy',
+    );
+
+    expect(parsed).not.toHaveProperty('kid');
+    expect(
+      buildTxtRecord({
+        domain: 'example.com',
+        uri: parsed.uri ?? '',
+        proto: parsed.proto ?? '',
+        auth: '',
+        desc: '',
+        docs: '',
+        dep: '',
+        pka: parsed.pka ?? '',
+      }),
+    ).toBe(
+      'v=aid2;u=https://api.example.com/mcp;p=mcp;k=ebVWLo_mVPlAeLES6KmLp5AfhTrmlb7X4OORC60ElmQ',
+    );
+  });
+});

--- a/protocol/examples.yml
+++ b/protocol/examples.yml
@@ -10,246 +10,127 @@ examples:
   tutorials:
     simple:
       domain: 'simple.agentcommunity.org'
-      record: 'v=aid1;u=https://api.example.com/mcp;p=mcp;a=pat;s=Basic MCP Example'
+      record: 'v=aid2;u=https://api.example.com/mcp;p=mcp;a=pat;s=Basic MCP Example'
       icon: '🤖'
       description: 'Simple MCP server example'
       category: 'tutorials'
 
-    v2_simple:
-      domain: 'v2-simple.agentcommunity.org'
-      record: 'v=aid2;u=https://api.example.com/mcp;p=mcp;a=pat;s=Basic MCP Example'
-      icon: '🤖'
-      description: 'v2 shadow for the simple MCP server example'
-      category: 'tutorials'
-
     local_docker:
       domain: 'local-docker.agentcommunity.org'
-      record: 'v=aid1;u=docker:myimage;p=local;s=Local Docker Agent'
+      record: 'v=aid2;u=docker:myimage;p=local;s=Local Docker Agent'
       icon: '🐳'
       description: 'Local agent via Docker'
       category: 'tutorials'
 
-    v2_local_docker:
-      domain: 'v2-local-docker.agentcommunity.org'
-      record: 'v=aid2;u=docker:myimage;p=local;s=Local Docker Agent'
-      icon: '🐳'
-      description: 'v2 shadow for the local Docker agent'
-      category: 'tutorials'
-
     messy:
       domain: 'messy.agentcommunity.org'
-      record: ' v=aid1 ; u=https://api.example.com/mcp ; p=mcp ; extra=ignored '
+      record: ' v=aid2 ; u=https://api.example.com/mcp ; p=mcp ; extra=ignored '
       icon: '🧹'
       description: 'Messy formatting with extra fields'
       category: 'tutorials'
 
-    v2_messy:
-      domain: 'v2-messy.agentcommunity.org'
-      record: ' v=aid2 ; u=https://api.example.com/mcp ; p=mcp ; extra=ignored '
-      icon: '🧹'
-      description: 'v2 shadow for messy formatting with extra fields'
-      category: 'tutorials'
-
     multi_string:
       domain: 'multi-string.agentcommunity.org'
-      record: 'v=aid1;u=https://api.example.com/mcp;p=mcp;s=Multi string part 1'
+      record: 'v=aid2;u=https://api.example.com/mcp;p=mcp;s=Multi string part 1'
       icon: '📄'
       description: 'Multi-string DNS record example'
       category: 'tutorials'
 
-    v2_multi_string:
-      domain: 'v2-multi-string.agentcommunity.org'
-      record: 'v=aid2;u=https://api.example.com/mcp;p=mcp;s=Multi string part 1'
-      icon: '📄'
-      description: 'v2 shadow for the multi-string DNS record example'
-      category: 'tutorials'
-
     pka_basic:
       domain: 'pka-basic.agentcommunity.org'
-      record: 'v=aid1;p=mcp;u=https://aid.agentcommunity.org/api/pka-demo;k=z2Cwtdw9EZzy1Mhv8ZmGRoMJPkJcU3amQQhpUJx35pKUs;i=p1;s=Live PKA Demo'
+      record: 'v=aid2;p=mcp;u=https://aid.agentcommunity.org/api/pka-demo;k=Eesj9h7MD0cRERrc_ICXu5Lb1WkokpkbWAkRcDsxUvA;s=Live PKA Demo'
       icon: '🔐'
       description: 'Live PKA endpoint proof demo'
       category: 'tutorials'
 
-    v2_pka_basic:
-      domain: 'v2-pka-basic.agentcommunity.org'
-      record: 'v=aid2;p=mcp;u=https://aid.agentcommunity.org/api/pka-demo;k=Eesj9h7MD0cRERrc_ICXu5Lb1WkokpkbWAkRcDsxUvA;s=Live PKA Demo'
-      icon: '🔐'
-      description: 'v2 shadow for the live PKA endpoint proof demo'
-      category: 'tutorials'
-
   # Feature complete & Reference examples
   reference:
-    complete_v1_2:
+    complete:
       domain: 'complete.agentcommunity.org'
-      record: 'v=aid1;p=mcp;u=https://api.complete.agentcommunity.org/mcp;d=https://docs.agentcommunity.org/complete;e=2026-12-31T23:59:59Z;s=Complete v1.2 with all features'
-      icon: '✨'
-      description: 'Complete v1.2 example with all features'
-      category: 'reference'
-
-    v2_complete:
-      domain: 'v2-complete.agentcommunity.org'
       record: 'v=aid2;p=mcp;u=https://api.complete.agentcommunity.org/mcp;d=https://docs.agentcommunity.org/complete;e=2026-12-31T23:59:59Z;s=Complete v2 with all features'
       icon: '✨'
-      description: 'v2 shadow with all features'
+      description: 'Complete v2 example with all features'
       category: 'reference'
 
     secure:
       domain: 'secure.agentcommunity.org'
-      record: 'v=aid1;u=https://api.secure.agentcommunity.org/mcp;p=mcp;a=pat;d=https://docs.agentcommunity.org/secure;s=Secure MCP with Auth'
-      icon: '🔒'
-      description: 'Secure service with auth'
-      category: 'reference'
-
-    v2_secure:
-      domain: 'v2-secure.agentcommunity.org'
       record: 'v=aid2;u=https://api.secure.agentcommunity.org/mcp;p=mcp;a=pat;d=https://docs.agentcommunity.org/secure;s=Secure MCP with Auth'
       icon: '🔒'
-      description: 'v2 shadow for the secure service with auth'
+      description: 'Secure service with auth'
       category: 'reference'
 
   # Real-world service examples
   real_world:
     supabase:
       domain: 'supabase.agentcommunity.org'
-      record: 'v=aid1;u=https://api.supabase.com/mcp;p=mcp;a=pat;d=https://supabase.com/docs/guides/getting-started/mcp;s=Supabase MCP (Mock Service)'
+      record: 'v=aid2;u=https://api.supabase.com/mcp;p=mcp;a=pat;d=https://supabase.com/docs/guides/getting-started/mcp;s=Supabase MCP (Mock Service)'
       icon: '/icons/supabase.svg'
       description: 'Supabase database service'
       category: 'real_world'
 
-    v2_supabase:
-      domain: 'v2-supabase.agentcommunity.org'
-      record: 'v=aid2;u=https://api.supabase.com/mcp;p=mcp;a=pat;d=https://supabase.com/docs/guides/getting-started/mcp;s=Supabase MCP (Mock Service)'
-      icon: '/icons/supabase.svg'
-      description: 'v2 shadow for the Supabase database service'
-      category: 'real_world'
-
     auth0:
       domain: 'auth0.agentcommunity.org'
-      record: 'v=aid1;u=https://ai.auth0.com/mcp;p=mcp;a=pat;d=https://auth0.com/docs/get-started/auth0-mcp-server;s=Auth0 MCP (Mock Service)'
+      record: 'v=aid2;u=https://ai.auth0.com/mcp;p=mcp;a=pat;d=https://auth0.com/docs/get-started/auth0-mcp-server;s=Auth0 MCP (Mock Service)'
       icon: '/icons/auth0.svg'
       description: 'Auth0 identity service'
       category: 'real_world'
 
-    v2_auth0:
-      domain: 'v2-auth0.agentcommunity.org'
-      record: 'v=aid2;u=https://ai.auth0.com/mcp;p=mcp;a=pat;d=https://auth0.com/docs/get-started/auth0-mcp-server;s=Auth0 MCP (Mock Service)'
-      icon: '/icons/auth0.svg'
-      description: 'v2 shadow for the Auth0 identity service'
-      category: 'real_world'
-
     firecrawl:
       domain: 'firecrawl.agentcommunity.org'
-      record: 'v=aid1;u=npx:firecrawl-mcp;p=local;d=https://docs.firecrawl.dev/mcp-server;s=Firecrawl Web Scraping Agent'
+      record: 'v=aid2;u=npx:firecrawl-mcp;p=local;d=https://docs.firecrawl.dev/mcp-server;s=Firecrawl Web Scraping Agent'
       icon: '🔥'
       description: 'Firecrawl web scraping (local)'
       category: 'real_world'
 
-    v2_firecrawl:
-      domain: 'v2-firecrawl.agentcommunity.org'
-      record: 'v=aid2;u=npx:firecrawl-mcp;p=local;d=https://docs.firecrawl.dev/mcp-server;s=Firecrawl Web Scraping Agent'
-      icon: '🔥'
-      description: 'v2 shadow for Firecrawl web scraping'
-      category: 'real_world'
-
     playwright:
       domain: 'playwright.agentcommunity.org'
-      record: 'v=aid1;u=https://api.playwright.dev;p=openapi;d=https://github.com/microsoft/playwright-mcp;s=Playwright OpenAPI (Mock Service)'
-      icon: '/icons/playwright.svg'
-      description: 'Playwright browser automation'
-      category: 'real_world'
-
-    v2_playwright:
-      domain: 'v2-playwright.agentcommunity.org'
       record: 'v=aid2;u=https://api.playwright.dev;p=openapi;d=https://github.com/microsoft/playwright-mcp;s=Playwright OpenAPI (Mock Service)'
       icon: '/icons/playwright.svg'
-      description: 'v2 shadow for Playwright browser automation'
+      description: 'Playwright browser automation'
       category: 'real_world'
 
   # Protocol showcase examples (demonstrate non-MCP protocols)
   protocols:
     a2a_showcase:
       domain: 'a2a.agentcommunity.org'
-      record: 'v=aid1;u=https://a2a.agentcommunity.org/.well-known/agent.json;p=a2a;d=https://a2aprotocol.ai/;s=A2A Protocol Showcase'
+      record: 'v=aid2;u=https://a2a.agentcommunity.org/.well-known/agent.json;p=a2a;d=https://a2aprotocol.ai/;s=A2A Protocol Showcase'
       icon: '🤝'
       description: 'Agent-to-Agent protocol example'
       category: 'protocols'
 
-    v2_a2a_showcase:
-      domain: 'v2-a2a.agentcommunity.org'
-      record: 'v=aid2;u=https://a2a.agentcommunity.org/.well-known/agent.json;p=a2a;d=https://a2aprotocol.ai/;s=A2A Protocol Showcase'
-      icon: '🤝'
-      description: 'v2 shadow for the Agent-to-Agent protocol example'
-      category: 'protocols'
-
     ucp_showcase:
       domain: 'ucp.agentcommunity.org'
-      record: 'v=aid1;u=https://ucp.agentcommunity.org/ucp;p=ucp;d=https://www.universalcommerce.io/;s=UCP Commerce Showcase'
+      record: 'v=aid2;u=https://ucp.agentcommunity.org/ucp;p=ucp;d=https://www.universalcommerce.io/;s=UCP Commerce Showcase'
       icon: '🛒'
       description: 'Universal Commerce Protocol example'
       category: 'protocols'
 
-    v2_ucp_showcase:
-      domain: 'v2-ucp.agentcommunity.org'
-      record: 'v=aid2;u=https://ucp.agentcommunity.org/ucp;p=ucp;d=https://www.universalcommerce.io/;s=UCP Commerce Showcase'
-      icon: '🛒'
-      description: 'v2 shadow for the Universal Commerce Protocol example'
-      category: 'protocols'
-
     graphql_showcase:
       domain: 'graphql.agentcommunity.org'
-      record: 'v=aid1;u=https://graphql.agentcommunity.org/graphql;p=graphql;d=https://graphql.org/;s=GraphQL Agent Showcase'
+      record: 'v=aid2;u=https://graphql.agentcommunity.org/graphql;p=graphql;d=https://graphql.org/;s=GraphQL Agent Showcase'
       icon: '◇'
       description: 'GraphQL API protocol example'
       category: 'protocols'
 
-    v2_graphql_showcase:
-      domain: 'v2-graphql.agentcommunity.org'
-      record: 'v=aid2;u=https://graphql.agentcommunity.org/graphql;p=graphql;d=https://graphql.org/;s=GraphQL Agent Showcase'
-      icon: '◇'
-      description: 'v2 shadow for the GraphQL API protocol example'
-      category: 'protocols'
-
     grpc_showcase:
       domain: 'grpc.agentcommunity.org'
-      record: 'v=aid1;u=https://grpc.agentcommunity.org;p=grpc;d=https://grpc.io/;s=gRPC Agent Showcase'
-      icon: '⚡'
-      description: 'gRPC protocol example'
-      category: 'protocols'
-
-    v2_grpc_showcase:
-      domain: 'v2-grpc.agentcommunity.org'
       record: 'v=aid2;u=https://grpc.agentcommunity.org;p=grpc;d=https://grpc.io/;s=gRPC Agent Showcase'
       icon: '⚡'
-      description: 'v2 shadow for the gRPC protocol example'
+      description: 'gRPC protocol example'
       category: 'protocols'
 
   # Error testing cases
   error_cases:
     no_server:
       domain: 'no-server.agentcommunity.org'
-      record: 'v=aid1;u=https://does-not-exist.agentcommunity.org:1234;p=mcp;s=Offline Agent'
+      record: 'v=aid2;u=https://does-not-exist.agentcommunity.org:1234;p=mcp;s=Offline Agent'
       icon: '❌'
       description: 'Non-responsive server for testing'
       category: 'error_cases'
 
-    v2_no_server:
-      domain: 'v2-no-server.agentcommunity.org'
-      record: 'v=aid2;u=https://does-not-exist.agentcommunity.org:1234;p=mcp;s=Offline Agent'
-      icon: '❌'
-      description: 'v2 shadow for non-responsive server testing'
-      category: 'error_cases'
-
     deprecated:
       domain: 'deprecated.agentcommunity.org'
-      record: 'v=aid1;u=https://api.deprecated.agentcommunity.org/mcp;p=mcp;a=pat;e=2025-12-31T23:59:59Z;d=https://docs.agentcommunity.org/migration;s=Deprecated - migrate soon'
-      icon: '⚠️'
-      description: 'Deprecated service example'
-      category: 'error_cases'
-
-    v2_deprecated:
-      domain: 'v2-deprecated.agentcommunity.org'
       record: 'v=aid2;u=https://api.deprecated.agentcommunity.org/mcp;p=mcp;a=pat;e=2025-12-31T23:59:59Z;d=https://docs.agentcommunity.org/migration;s=Deprecated - migrate soon'
       icon: '⚠️'
-      description: 'v2 shadow for the deprecated service example'
+      description: 'Deprecated service example'
       category: 'error_cases'

--- a/scripts/generate-examples.ts
+++ b/scripts/generate-examples.ts
@@ -32,6 +32,43 @@ interface FormattedExample extends ExampleRecord {
   name: string;
 }
 
+function parseExampleRecord(record: string): Map<string, string> {
+  const entries = record
+    .split(';')
+    .map((part) => part.trim())
+    .filter(Boolean)
+    .map((part) => {
+      const separator = part.indexOf('=');
+      if (separator === -1) return [part.toLowerCase(), ''] as const;
+      return [
+        part.slice(0, separator).trim().toLowerCase(),
+        part.slice(separator + 1).trim(),
+      ] as const;
+    });
+
+  return new Map(entries);
+}
+
+function validateV2ShowcaseExamples(examples: ExamplesData): void {
+  const failures: string[] = [];
+
+  Object.entries(examples.examples).forEach(([category, categoryExamples]) => {
+    Object.entries(categoryExamples).forEach(([name, example]) => {
+      const fields = parseExampleRecord(example.record);
+      if (fields.get('v') !== 'aid2') {
+        failures.push(`${category}.${name}: expected v=aid2`);
+      }
+      if (fields.has('i') || fields.has('kid')) {
+        failures.push(`${category}.${name}: aid2 examples must not publish kid/i`);
+      }
+    });
+  });
+
+  if (failures.length > 0) {
+    throw new Error(`Showcase examples must be v2-only:\n${failures.join('\n')}`);
+  }
+}
+
 const GENERATED_WARNING = `/**
  * GENERATED FILE - DO NOT EDIT
  *
@@ -178,6 +215,7 @@ try {
   const yamlPath = path.resolve(process.cwd(), 'protocol/examples.yml');
   const yamlContent = readFileSync(yamlPath, 'utf8');
   const examples = parse(yamlContent) as ExamplesData;
+  validateV2ShowcaseExamples(examples);
 
   // Generate Terraform locals
   const terraformContent = generateTerraformLocals(examples);

--- a/showcase/terraform/README.md
+++ b/showcase/terraform/README.md
@@ -105,13 +105,14 @@ If you need to test record changes against a sandbox zone, point `cloudflare_zon
 
 ## Spec alignment
 
-The records published here demonstrate the complete AID v1.2 surface area. Relevant specification sections:
+The records published here demonstrate the AID v2 surface area. Relevant specification sections:
 
 - **§2 — TXT Record Specification**: format, required keys, key aliases, multi-string handling.
-- **§2.4 — Exact-host semantics and explicit delegation**: covered by the optional `include_protocol_specific` records.
+- **§2.4 — Exact-host semantics and explicit delegation**: canonical base-name behavior.
+- **§2.5 — Multiple Protocols And Protocol-Specific Compatibility Names**: covered by the optional `include_protocol_specific` records.
 - **§4 — DNS and Caching**: TTL recommendation enforced via `record_ttl`.
-- **Appendix B — Protocol Registry**: every `proto` token in the registry has a representative showcase record (`mcp`, `a2a`, `openapi`, `grpc`, `graphql`, `local`, `ucp`).
-- **Appendix D — PKA Handshake**: `_agent.pka-basic` exercises the live PKA endpoint.
+- **§7.2 — Protocol Tokens**: every protocol token has a representative showcase record (`mcp`, `a2a`, `openapi`, `grpc`, `graphql`, `local`, `ucp`).
+- **Appendix B — PKA Handshake**: `_agent.pka-basic` exercises the live PKA endpoint.
 
 The full spec lives at [`packages/docs/specification.md`](../../packages/docs/specification.md).
 
@@ -132,7 +133,7 @@ The full spec lives at [`packages/docs/specification.md`](../../packages/docs/sp
 
 ## References
 
-- [Specification](../../packages/docs/specification.md) — AID v1.2.
+- [Specification](../../packages/docs/specification.md) — AID v2.
 - [`protocol/examples.yml`](../../protocol/examples.yml) — source of truth for showcase records.
 - [`scripts/generate-examples.ts`](../../scripts/generate-examples.ts) — generator that emits `examples.tf` and the web constants.
 - [`.github/workflows/showcase-dns.yml`](../../.github/workflows/showcase-dns.yml) — the CI deployment workflow.

--- a/showcase/terraform/examples.tf
+++ b/showcase/terraform/examples.tf
@@ -11,171 +11,86 @@
 locals {
   a2a_showcase = {
     name  = "_agent.a2a"
-    value = "v=aid1;u=https://a2a.agentcommunity.org/.well-known/agent.json;p=a2a;d=https://a2aprotocol.ai/;s=A2A Protocol Showcase"
+    value = "v=aid2;u=https://a2a.agentcommunity.org/.well-known/agent.json;p=a2a;d=https://a2aprotocol.ai/;s=A2A Protocol Showcase"
   }
 
   auth0 = {
     name  = "_agent.auth0"
-    value = "v=aid1;u=https://ai.auth0.com/mcp;p=mcp;a=pat;d=https://auth0.com/docs/get-started/auth0-mcp-server;s=Auth0 MCP (Mock Service)"
+    value = "v=aid2;u=https://ai.auth0.com/mcp;p=mcp;a=pat;d=https://auth0.com/docs/get-started/auth0-mcp-server;s=Auth0 MCP (Mock Service)"
   }
 
-  complete_v1_2 = {
+  complete = {
     name  = "_agent.complete"
-    value = "v=aid1;p=mcp;u=https://api.complete.agentcommunity.org/mcp;d=https://docs.agentcommunity.org/complete;e=2026-12-31T23:59:59Z;s=Complete v1.2 with all features"
+    value = "v=aid2;p=mcp;u=https://api.complete.agentcommunity.org/mcp;d=https://docs.agentcommunity.org/complete;e=2026-12-31T23:59:59Z;s=Complete v2 with all features"
   }
 
   deprecated = {
     name  = "_agent.deprecated"
-    value = "v=aid1;u=https://api.deprecated.agentcommunity.org/mcp;p=mcp;a=pat;e=2025-12-31T23:59:59Z;d=https://docs.agentcommunity.org/migration;s=Deprecated - migrate soon"
+    value = "v=aid2;u=https://api.deprecated.agentcommunity.org/mcp;p=mcp;a=pat;e=2025-12-31T23:59:59Z;d=https://docs.agentcommunity.org/migration;s=Deprecated - migrate soon"
   }
 
   firecrawl = {
     name  = "_agent.firecrawl"
-    value = "v=aid1;u=npx:firecrawl-mcp;p=local;d=https://docs.firecrawl.dev/mcp-server;s=Firecrawl Web Scraping Agent"
+    value = "v=aid2;u=npx:firecrawl-mcp;p=local;d=https://docs.firecrawl.dev/mcp-server;s=Firecrawl Web Scraping Agent"
   }
 
   graphql_showcase = {
     name  = "_agent.graphql"
-    value = "v=aid1;u=https://graphql.agentcommunity.org/graphql;p=graphql;d=https://graphql.org/;s=GraphQL Agent Showcase"
+    value = "v=aid2;u=https://graphql.agentcommunity.org/graphql;p=graphql;d=https://graphql.org/;s=GraphQL Agent Showcase"
   }
 
   grpc_showcase = {
     name  = "_agent.grpc"
-    value = "v=aid1;u=https://grpc.agentcommunity.org;p=grpc;d=https://grpc.io/;s=gRPC Agent Showcase"
+    value = "v=aid2;u=https://grpc.agentcommunity.org;p=grpc;d=https://grpc.io/;s=gRPC Agent Showcase"
   }
 
   local_docker = {
     name  = "_agent.local-docker"
-    value = "v=aid1;u=docker:myimage;p=local;s=Local Docker Agent"
+    value = "v=aid2;u=docker:myimage;p=local;s=Local Docker Agent"
   }
 
   messy = {
     name  = "_agent.messy"
-    value = " v=aid1 ; u=https://api.example.com/mcp ; p=mcp ; extra=ignored "
+    value = " v=aid2 ; u=https://api.example.com/mcp ; p=mcp ; extra=ignored "
   }
 
   multi_string = {
     name  = "_agent.multi-string"
-    value = "v=aid1;u=https://api.example.com/mcp;p=mcp;s=Multi string part 1"
+    value = "v=aid2;u=https://api.example.com/mcp;p=mcp;s=Multi string part 1"
   }
 
   no_server = {
     name  = "_agent.no-server"
-    value = "v=aid1;u=https://does-not-exist.agentcommunity.org:1234;p=mcp;s=Offline Agent"
+    value = "v=aid2;u=https://does-not-exist.agentcommunity.org:1234;p=mcp;s=Offline Agent"
   }
 
   pka_basic = {
     name  = "_agent.pka-basic"
-    value = "v=aid1;p=mcp;u=https://aid.agentcommunity.org/api/pka-demo;k=z2Cwtdw9EZzy1Mhv8ZmGRoMJPkJcU3amQQhpUJx35pKUs;i=p1;s=Live PKA Demo"
+    value = "v=aid2;p=mcp;u=https://aid.agentcommunity.org/api/pka-demo;k=Eesj9h7MD0cRERrc_ICXu5Lb1WkokpkbWAkRcDsxUvA;s=Live PKA Demo"
   }
 
   playwright = {
     name  = "_agent.playwright"
-    value = "v=aid1;u=https://api.playwright.dev;p=openapi;d=https://github.com/microsoft/playwright-mcp;s=Playwright OpenAPI (Mock Service)"
+    value = "v=aid2;u=https://api.playwright.dev;p=openapi;d=https://github.com/microsoft/playwright-mcp;s=Playwright OpenAPI (Mock Service)"
   }
 
   secure = {
     name  = "_agent.secure"
-    value = "v=aid1;u=https://api.secure.agentcommunity.org/mcp;p=mcp;a=pat;d=https://docs.agentcommunity.org/secure;s=Secure MCP with Auth"
+    value = "v=aid2;u=https://api.secure.agentcommunity.org/mcp;p=mcp;a=pat;d=https://docs.agentcommunity.org/secure;s=Secure MCP with Auth"
   }
 
   simple = {
     name  = "_agent.simple"
-    value = "v=aid1;u=https://api.example.com/mcp;p=mcp;a=pat;s=Basic MCP Example"
+    value = "v=aid2;u=https://api.example.com/mcp;p=mcp;a=pat;s=Basic MCP Example"
   }
 
   supabase = {
     name  = "_agent.supabase"
-    value = "v=aid1;u=https://api.supabase.com/mcp;p=mcp;a=pat;d=https://supabase.com/docs/guides/getting-started/mcp;s=Supabase MCP (Mock Service)"
+    value = "v=aid2;u=https://api.supabase.com/mcp;p=mcp;a=pat;d=https://supabase.com/docs/guides/getting-started/mcp;s=Supabase MCP (Mock Service)"
   }
 
   ucp_showcase = {
     name  = "_agent.ucp"
-    value = "v=aid1;u=https://ucp.agentcommunity.org/ucp;p=ucp;d=https://www.universalcommerce.io/;s=UCP Commerce Showcase"
-  }
-
-  v2_a2a_showcase = {
-    name  = "_agent.v2-a2a"
-    value = "v=aid2;u=https://a2a.agentcommunity.org/.well-known/agent.json;p=a2a;d=https://a2aprotocol.ai/;s=A2A Protocol Showcase"
-  }
-
-  v2_auth0 = {
-    name  = "_agent.v2-auth0"
-    value = "v=aid2;u=https://ai.auth0.com/mcp;p=mcp;a=pat;d=https://auth0.com/docs/get-started/auth0-mcp-server;s=Auth0 MCP (Mock Service)"
-  }
-
-  v2_complete = {
-    name  = "_agent.v2-complete"
-    value = "v=aid2;p=mcp;u=https://api.complete.agentcommunity.org/mcp;d=https://docs.agentcommunity.org/complete;e=2026-12-31T23:59:59Z;s=Complete v2 with all features"
-  }
-
-  v2_deprecated = {
-    name  = "_agent.v2-deprecated"
-    value = "v=aid2;u=https://api.deprecated.agentcommunity.org/mcp;p=mcp;a=pat;e=2025-12-31T23:59:59Z;d=https://docs.agentcommunity.org/migration;s=Deprecated - migrate soon"
-  }
-
-  v2_firecrawl = {
-    name  = "_agent.v2-firecrawl"
-    value = "v=aid2;u=npx:firecrawl-mcp;p=local;d=https://docs.firecrawl.dev/mcp-server;s=Firecrawl Web Scraping Agent"
-  }
-
-  v2_graphql_showcase = {
-    name  = "_agent.v2-graphql"
-    value = "v=aid2;u=https://graphql.agentcommunity.org/graphql;p=graphql;d=https://graphql.org/;s=GraphQL Agent Showcase"
-  }
-
-  v2_grpc_showcase = {
-    name  = "_agent.v2-grpc"
-    value = "v=aid2;u=https://grpc.agentcommunity.org;p=grpc;d=https://grpc.io/;s=gRPC Agent Showcase"
-  }
-
-  v2_local_docker = {
-    name  = "_agent.v2-local-docker"
-    value = "v=aid2;u=docker:myimage;p=local;s=Local Docker Agent"
-  }
-
-  v2_messy = {
-    name  = "_agent.v2-messy"
-    value = " v=aid2 ; u=https://api.example.com/mcp ; p=mcp ; extra=ignored "
-  }
-
-  v2_multi_string = {
-    name  = "_agent.v2-multi-string"
-    value = "v=aid2;u=https://api.example.com/mcp;p=mcp;s=Multi string part 1"
-  }
-
-  v2_no_server = {
-    name  = "_agent.v2-no-server"
-    value = "v=aid2;u=https://does-not-exist.agentcommunity.org:1234;p=mcp;s=Offline Agent"
-  }
-
-  v2_pka_basic = {
-    name  = "_agent.v2-pka-basic"
-    value = "v=aid2;p=mcp;u=https://aid.agentcommunity.org/api/pka-demo;k=Eesj9h7MD0cRERrc_ICXu5Lb1WkokpkbWAkRcDsxUvA;s=Live PKA Demo"
-  }
-
-  v2_playwright = {
-    name  = "_agent.v2-playwright"
-    value = "v=aid2;u=https://api.playwright.dev;p=openapi;d=https://github.com/microsoft/playwright-mcp;s=Playwright OpenAPI (Mock Service)"
-  }
-
-  v2_secure = {
-    name  = "_agent.v2-secure"
-    value = "v=aid2;u=https://api.secure.agentcommunity.org/mcp;p=mcp;a=pat;d=https://docs.agentcommunity.org/secure;s=Secure MCP with Auth"
-  }
-
-  v2_simple = {
-    name  = "_agent.v2-simple"
-    value = "v=aid2;u=https://api.example.com/mcp;p=mcp;a=pat;s=Basic MCP Example"
-  }
-
-  v2_supabase = {
-    name  = "_agent.v2-supabase"
-    value = "v=aid2;u=https://api.supabase.com/mcp;p=mcp;a=pat;d=https://supabase.com/docs/guides/getting-started/mcp;s=Supabase MCP (Mock Service)"
-  }
-
-  v2_ucp_showcase = {
-    name  = "_agent.v2-ucp"
     value = "v=aid2;u=https://ucp.agentcommunity.org/ucp;p=ucp;d=https://www.universalcommerce.io/;s=UCP Commerce Showcase"
   }
 
@@ -183,7 +98,7 @@ locals {
   all_examples = {
     a2a_showcase = local.a2a_showcase
     auth0 = local.auth0
-    complete_v1_2 = local.complete_v1_2
+    complete = local.complete
     deprecated = local.deprecated
     firecrawl = local.firecrawl
     graphql_showcase = local.graphql_showcase
@@ -198,22 +113,5 @@ locals {
     simple = local.simple
     supabase = local.supabase
     ucp_showcase = local.ucp_showcase
-    v2_a2a_showcase = local.v2_a2a_showcase
-    v2_auth0 = local.v2_auth0
-    v2_complete = local.v2_complete
-    v2_deprecated = local.v2_deprecated
-    v2_firecrawl = local.v2_firecrawl
-    v2_graphql_showcase = local.v2_graphql_showcase
-    v2_grpc_showcase = local.v2_grpc_showcase
-    v2_local_docker = local.v2_local_docker
-    v2_messy = local.v2_messy
-    v2_multi_string = local.v2_multi_string
-    v2_no_server = local.v2_no_server
-    v2_pka_basic = local.v2_pka_basic
-    v2_playwright = local.v2_playwright
-    v2_secure = local.v2_secure
-    v2_simple = local.v2_simple
-    v2_supabase = local.v2_supabase
-    v2_ucp_showcase = local.v2_ucp_showcase
   }
 }

--- a/showcase/terraform/main.tf
+++ b/showcase/terraform/main.tf
@@ -28,9 +28,9 @@ variable "record_ttl" {
 }
 
 # Optional: include protocol-specific subdomain examples like _agent._mcp.<sub> and _agent._a2a.<sub>.
-# These are NOT canonical; base `_agent.<domain>` remains primary. See spec §2.4.
+# These are NOT canonical; base `_agent.<domain>` remains primary. See spec §2.5.
 variable "include_protocol_specific" {
-  description = "If true, also create protocol-specific example records at _agent._<proto>.<sub>." 
+  description = "If true, also create protocol-specific example records at _agent._<proto>.<sub>."
   type        = bool
   default     = false
 }
@@ -47,16 +47,16 @@ locals {
   # We will define the common prefix here to keep the records clean
   record_prefix = "_agent"
 
-  # Optional protocol-specific examples (underscore form). See spec §2.4.
+  # Optional protocol-specific examples (underscore form). See spec §2.5.
   # These demonstrate exposing multiple distinct services. They are NOT the default.
   protocol_specific_records = {
     mcp_simple = {
       name  = "${local.record_prefix}._mcp.simple"
-      value = "v=aid1;u=https://api.example.com/mcp;p=mcp;s=Example via protocol-specific subdomain (optional)"
+      value = "v=aid2;u=https://api.example.com/mcp;p=mcp;s=Example via protocol-specific subdomain (optional)"
     }
     a2a_gateway = {
       name  = "${local.record_prefix}._a2a.gateway"
-      value = "v=aid1;u=https://a2a.example.com/ping;p=a2a;s=A2A gateway (optional)"
+      value = "v=aid2;u=https://a2a.example.com/ping;p=a2a;s=A2A gateway (optional)"
     }
   }
 

--- a/tracking/NIST_COMMENT_DRAFT.md
+++ b/tracking/NIST_COMMENT_DRAFT.md
@@ -17,12 +17,12 @@ How does a client, given only a domain name, discover where the agent is, what p
 A provider publishes a DNS TXT record at `_agent.<domain>`:
 
 ```
-_agent.acme.com. 300 IN TXT "v=aid1;p=mcp;u=https://agent.acme.com/mcp;k=z6MkrTQ...;i=a1;a=oauth2_code"
+_agent.acme.com. 300 IN TXT "v=aid2;p=mcp;u=https://agent.acme.com/mcp;k=Eesj9h7MD0cRERrc_ICXu5Lb1WkokpkbWAkRcDsxUvA;a=oauth2_code"
 ```
 
-That one record tells a client: the agent lives at this URL, speaks MCP, expects OAuth 2.0 code flow, and here's an Ed25519 public key you can use to verify the endpoint controls the private key. No prior enrollment. No central registry. Just DNS, which organizations already own and manage.
+That one record tells a client: the agent lives at this URL, speaks MCP, expects OAuth 2.0 code flow, and publishes an Ed25519 public key you can use to verify that the endpoint controls the corresponding private key. No prior enrollment. No central registry. Just DNS, which organizations already own and manage.
 
-The spec is at v1.2 (finalized February 2026). We have SDKs in TypeScript, Go, Python, Rust, .NET, and Java, plus a CLI validation tool called aid-doctor. The full specification and all code are at:
+The current spec is v2. We have SDKs in TypeScript, Go, Python, Rust, .NET, and Java, plus a CLI validation tool called aid-doctor. The full specification and all code are at:
 
 - Project: https://aid.agentcommunity.org
 - Specification: https://aid.agentcommunity.org/docs/specification
@@ -30,16 +30,16 @@ The spec is at v1.2 (finalized February 2026). We have SDKs in TypeScript, Go, P
 
 ## How this maps to your questions
 
-**Identification (your Question Area 2).** You ask how agents should be identified and what metadata is essential. AID's answer: anchor identity in DNS, the same way organizations already establish identity for email (SPF/DKIM), web services (TLS), and everything else. The record carries protocol, endpoint URI, auth scheme, docs URL, deprecation timestamp, and an optional public key with a rotation ID. Domain ownership is organizational identity. No new namespace needed.
+**Identification (your Question Area 2).** You ask how agents should be identified and what metadata is essential. AID's answer: anchor identity in DNS, the same way organizations already establish identity for email (SPF/DKIM), web services (TLS), and everything else. The record carries protocol, endpoint URI, auth scheme, docs URL, deprecation timestamp, and an optional public key for endpoint proof. Domain ownership is organizational identity. No new namespace needed.
 
 **Authentication (Question Area 3).** You ask what strong authentication looks like for agents and how to handle key management. AID includes a mechanism called PKA (Public Key for Agent) built on Ed25519 and HTTP Message Signatures (RFC 9421). The flow:
 
-1. Client sends a random nonce as an AID-Challenge header
-2. Server signs it with the Ed25519 private key
-3. Client verifies against the public key in DNS
-4. A 300-second freshness window prevents replay
+1. Client sends a random nonce for the PKA proof request.
+2. Server returns an RFC 9421 HTTP Message Signature over the request method, target URI, authority, and response status.
+3. Client verifies the Ed25519 signature against the public key in DNS and derives `keyid` from that key.
+4. `created`, `expires`, nonce binding, and `Cache-Control: no-store` prevent replay.
 
-Key rotation uses the `kid` field. Clients detect downgrade if a previously present PKA disappears. DNSSEC protects the key material in transit. The result: cryptographic proof that the endpoint is controlled by whoever controls that domain's DNS, with no prior trust relationship required.
+AID core publishes the current endpoint-proof key and leaves managed rotation profiles to higher layers. Clients can detect downgrade if a previously present PKA disappears. DNSSEC can protect the key material in transit. The result: cryptographic proof that the endpoint is controlled by whoever controls that domain's DNS, with no prior trust relationship required.
 
 **Authorization and zero trust (Question Area 4).** AID defines two enterprise policy modes. "Balanced" verifies PKA when present, prefers DNSSEC, allows HTTP fallback, and warns on downgrades. "Strict" requires PKA and DNSSEC, disables fallback, and fails on any downgrade. Beyond that: HTTPS is mandatory for remote agents, cross-origin redirects are blocked, and local execution requires explicit user consent, integrity fingerprinting, and sandboxing. These are the kinds of controls SP 800-207 calls for.
 


### PR DESCRIPTION
## Summary

- Make the public web/showcase examples v2-only and regenerate the web + Terraform example outputs from `protocol/examples.yml`.
- Remove legacy `kid/i` rehydration from the web creator and built-in resolver scenarios.
- Make `/api/pka-demo` serve only the AID v2 `Accept-Signature` PKA path and reject the legacy `AID-Challenge` handshake.
- Surface the derived PKA `keyid` through the engine report and web handshake/discovery UI data.
- Refresh the docs/export manifest for the v2 wording cleanup already on this branch.

## Verification

- `pnpm -C packages/web test`
- `pnpm -C packages/aid-engine test`
- `pnpm docs:verify`
- `git diff --check --cached`
- Earlier full matrix on this branch: `pnpm build`, `pnpm test`, `pnpm test:parity`, `pnpm lint`

## Notes

- `terraform fmt -check showcase/terraform` could not be run locally because neither Terraform nor OpenTofu is installed in this environment.