### PR TITLE
chore(release): normalize npm package repository metadata

### DIFF
--- a/packages/aid-conformance/package.json
+++ b/packages/aid-conformance/package.json
@@ -14,7 +14,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/agentcommunity/agent-identity-discovery.git",
+    "url": "https://github.com/agentcommunity/agent-identity-discovery",
     "directory": "packages/aid-conformance"
   },
   "homepage": "https://aid.agentcommunity.org",

--- a/packages/aid-doctor/package.json
+++ b/packages/aid-doctor/package.json
@@ -14,7 +14,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/agentcommunity/agent-identity-discovery.git",
+    "url": "https://github.com/agentcommunity/agent-identity-discovery",
     "directory": "packages/aid-doctor"
   },
   "homepage": "https://aid.agentcommunity.org",

--- a/packages/aid-engine/package.json
+++ b/packages/aid-engine/package.json
@@ -13,7 +13,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/agentcommunity/agent-identity-discovery.git",
+    "url": "https://github.com/agentcommunity/agent-identity-discovery",
     "directory": "packages/aid-engine"
   },
   "type": "module",

--- a/packages/aid/package.json
+++ b/packages/aid/package.json
@@ -14,7 +14,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/agentcommunity/agent-identity-discovery.git",
+    "url": "https://github.com/agentcommunity/agent-identity-discovery",
     "directory": "packages/aid"
   },
   "homepage": "https://aid.agentcommunity.org",


### PR DESCRIPTION
## Summary
- normalize repository.url for the four npm-published packages to the exact GitHub repository URL
- retry the v2.1.0 npm release path after the OIDC publish failed with npm E404 permission errors

## Verification
- pnpm install --frozen-lockfile
- git diff --check
- local changeset publish attempt confirmed @agentcommunity/aid, aid-engine, aid-doctor, and aid-conformance 2.1.0 remain unpublished; it failed locally because this machine has no npm auth