### PR TITLE
chore(release): publish package metadata updates

### DIFF
--- a/packages/aid-conformance/CHANGELOG.md
+++ b/packages/aid-conformance/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @agentcommunity/aid-conformance
 
+## 2.1.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @agentcommunity/aid@2.1.1
+
 ## 2.1.0
 
 ### Minor Changes

--- a/packages/aid-conformance/package.json
+++ b/packages/aid-conformance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentcommunity/aid-conformance",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Conformance fixtures and runner for Agent Identity & Discovery (AID)",
   "keywords": [
     "agent",

--- a/packages/aid-doctor/CHANGELOG.md
+++ b/packages/aid-doctor/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @agentcommunity/aid-doctor
 
+## 2.1.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @agentcommunity/aid@2.1.1
+  - @agentcommunity/aid-engine@2.1.1
+
 ## 2.1.0
 
 ### Minor Changes

--- a/packages/aid-doctor/package.json
+++ b/packages/aid-doctor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentcommunity/aid-doctor",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "CLI tool for Agent Identity & Discovery (AID) - validate and check AID records",
   "keywords": [
     "agent",

--- a/packages/aid-engine/CHANGELOG.md
+++ b/packages/aid-engine/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @agentcommunity/aid-engine
 
+## 2.1.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @agentcommunity/aid@2.1.1
+
 ## 2.1.0
 
 ### Minor Changes

--- a/packages/aid-engine/package.json
+++ b/packages/aid-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentcommunity/aid-engine",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Core engine for Agent Identity & Discovery (AID) validation and discovery",
   "keywords": [
     "agent",

--- a/packages/aid-py/README.md
+++ b/packages/aid-py/README.md
@@ -1,11 +1,17 @@
 # aid-discovery (Python)
 
-> Official Python implementation of the [Agent Identity & Discovery (AID)](https://github.com/agentcommunity/agent-identity-discovery) specification.
+> Official Python implementation of the [Agent Identity & Discovery (AID)](https://aid.agentcommunity.org) specification.
 
 [![PyPI version](https://img.shields.io/pypi/v/aid-discovery.svg?color=blue)](https://pypi.org/project/aid-discovery/)
 [![Python 3.8+](https://img.shields.io/badge/python-3.8+-blue.svg)](https://www.python.org/downloads/)
 
 AID enables you to discover AI agents by domain name using DNS TXT records. Type a domain, get the agent's endpoint and protocol - that's it.
+
+Built by the team at [agentcommunity.org](https://agentcommunity.org).
+
+- **Website**: [aid.agentcommunity.org](https://aid.agentcommunity.org)
+- **Docs**: [aid.agentcommunity.org](https://aid.agentcommunity.org)
+- **GitHub**: [github.com/agentcommunity/agent-identity-discovery](https://github.com/agentcommunity/agent-identity-discovery)
 
 ## Installation
 

--- a/packages/aid-py/aid_discovery.egg-info/PKG-INFO
+++ b/packages/aid-py/aid_discovery.egg-info/PKG-INFO
@@ -1,11 +1,14 @@
 Metadata-Version: 2.4
 Name: aid-discovery
-Version: 2.1.0
-Summary: Python library for Agent Identity & Discovery (AID) - v2.1.0 release
+Version: 2.1.1
+Summary: Python library for Agent Identity & Discovery (AID), a DNS-based discovery protocol for AI agents
 Author-email: Agent Community <maintainers@agentcommunity.org>
 License: MIT
-Project-URL: Homepage, https://github.com/agentcommunity/agent-identity-discovery
+Project-URL: Homepage, https://aid.agentcommunity.org
 Project-URL: Repository, https://github.com/agentcommunity/agent-identity-discovery
+Project-URL: Documentation, https://aid.agentcommunity.org
+Project-URL: Agent Community, https://agentcommunity.org/developers
+Keywords: agent,discovery,dns,mcp,a2a,ai,aid,txt-record
 Classifier: Development Status :: 5 - Production/Stable
 Classifier: Intended Audience :: Developers
 Classifier: License :: OSI Approved :: MIT License
@@ -30,12 +33,18 @@ Requires-Dist: cryptography>=42; extra == "pka"
 
 # aid-discovery (Python)
 
-> Official Python implementation of the [Agent Identity & Discovery (AID)](https://github.com/agentcommunity/agent-identity-discovery) specification.
+> Official Python implementation of the [Agent Identity & Discovery (AID)](https://aid.agentcommunity.org) specification.
 
 [![PyPI version](https://img.shields.io/pypi/v/aid-discovery.svg?color=blue)](https://pypi.org/project/aid-discovery/)
 [![Python 3.8+](https://img.shields.io/badge/python-3.8+-blue.svg)](https://www.python.org/downloads/)
 
 AID enables you to discover AI agents by domain name using DNS TXT records. Type a domain, get the agent's endpoint and protocol - that's it.
+
+Built by the team at [agentcommunity.org](https://agentcommunity.org).
+
+- **Website**: [aid.agentcommunity.org](https://aid.agentcommunity.org)
+- **Docs**: [aid.agentcommunity.org](https://aid.agentcommunity.org)
+- **GitHub**: [github.com/agentcommunity/agent-identity-discovery](https://github.com/agentcommunity/agent-identity-discovery)
 
 ## Installation
 

--- a/packages/aid-py/pyproject.toml
+++ b/packages/aid-py/pyproject.toml
@@ -4,13 +4,14 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aid-discovery"
-version = "2.1.0"
-description = "Python library for Agent Identity & Discovery (AID) - v2.1.0 release"
+version = "2.1.1"
+description = "Python library for Agent Identity & Discovery (AID), a DNS-based discovery protocol for AI agents"
 authors = [{ name = "Agent Community", email = "maintainers@agentcommunity.org" }]
 readme = "README.md"
 license = { text = "MIT" }
 requires-python = ">=3.8"
 dependencies = ["dnspython>=2.6.0", "idna>=3.6"]
+keywords = ["agent", "discovery", "dns", "mcp", "a2a", "ai", "aid", "txt-record"]
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
@@ -28,8 +29,10 @@ classifiers = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/agentcommunity/agent-identity-discovery"
+Homepage = "https://aid.agentcommunity.org"
 Repository = "https://github.com/agentcommunity/agent-identity-discovery"
+Documentation = "https://aid.agentcommunity.org"
+"Agent Community" = "https://agentcommunity.org/developers"
 
 [project.optional-dependencies]
 dev = ["pytest>=8"]

--- a/packages/aid/CHANGELOG.md
+++ b/packages/aid/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @agentcommunity/aid
 
+## 2.1.1
+
+### Patch Changes
+
+- Improve package-registry discoverability with AID and DNS TXT record keywords, canonical Agent Community links, and corrected public README documentation URLs.
+
 ## 2.1.0
 
 ### Minor Changes

--- a/packages/aid/README.md
+++ b/packages/aid/README.md
@@ -13,7 +13,7 @@ No more hunting through API docs. No more manual configuration. It's the zero-fr
 Built by the team at [agentcommunity.org](https://agentcommunity.org).
 
 - **Website**: [aid.agentcommunity.org](https://aid.agentcommunity.org)
-- **Docs**: [docs.agentcommunity.org/aid](https://docs.agentcommunity.org/aid)
+- **Docs**: [aid.agentcommunity.org](https://aid.agentcommunity.org)
 - **GitHub**: [github.com/agentcommunity/agent-identity-discovery](https://github.com/agentcommunity/agent-identity-discovery)
 
 ## Install

--- a/packages/aid/package.json
+++ b/packages/aid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentcommunity/aid",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Agent Identity & Discovery (AID) - DNS-based discovery protocol for AI agents",
   "keywords": [
     "agent",
@@ -8,7 +8,9 @@
     "dns",
     "mcp",
     "a2a",
-    "ai"
+    "ai",
+    "aid",
+    "txt-record"
   ],
   "author": "Agent Community",
   "license": "MIT",

--- a/packages/web/src/tests/version-metadata.test.ts
+++ b/packages/web/src/tests/version-metadata.test.ts
@@ -6,7 +6,7 @@ describe('AID version metadata', () => {
   it('uses the v2 protocol version for public web display', () => {
     expect(AID_SPEC_VERSION).toBe('2.1.0');
     expect(AID_VERSION).toBe(AID_SPEC_VERSION);
-    expect(AID_SDK_VERSION).toBe('2.1.0');
+    expect(AID_SDK_VERSION).toBe('2.1.1');
   });
 
   it('returns the spec version from the version API', async () => {


### PR DESCRIPTION
## Summary

- Publish `aid-discovery` 2.1.1 with version-free PyPI metadata, registry keywords, canonical AID links, and an Agent Community apex-domain backlink.
- Publish the synchronized npm package set at 2.1.1, including corrected npm README links and improved `@agentcommunity/aid` keywords.
- Keep the AID specification version at 2.1.0 while updating the SDK release-version assertion to 2.1.1.

## Why

PyPI metadata is immutable and 2.1.0 is already published, so the metadata correction requires 2.1.1. Registry scanners need package metadata that links back to Agent Community. The npm README also linked to the non-resolving `docs.agentcommunity.org/aid` host.

## Release behavior

Merging this PR to `main` triggers both jobs in `.github/workflows/release.yml` because the commit and PR title contain `chore(release)`:

- npm: `pnpm changeset publish` publishes `@agentcommunity/aid`, `aid-conformance`, `aid-engine`, and `aid-doctor` at 2.1.1 with provenance.
- PyPI: builds and publishes the `aid-discovery` 2.1.1 wheel and sdist using trusted publishing.

All five target package versions were checked and are currently available. The existing `skip-existing` behavior is correct; PyPI 2.1.0 already has both wheel and sdist.

## Verification

- `PATH="$PWD/packages/aid-py/.venv/bin:$PATH" pnpm turbo run build test lint` — 17/17 tasks passed.
- `pnpm docs:verify` — passed; docs export manifest unchanged.
- Python 2.1.1 wheel and sdist built; `twine check` passed; artifact metadata and README links verified.
- `pnpm pack` verified workspace dependencies become exact 2.1.1 registry dependencies.
- Release workflow and `pypi` GitHub environment verified; the previous synchronized npm/PyPI release completed successfully.
- Independent code review found no actionable issues.

## Scope

No Python CLI is added. The package has no existing CLI module; a useful resolver CLI belongs in a deliberate 2.2.0 feature release. `dmv-agent` is in a different repository and remains out of scope.