### PR TITLE
docs(sdk): make official package claims reproducible

### DIFF
--- a/.changeset/famous-berries-tap.md
+++ b/.changeset/famous-berries-tap.md
@@ -1,0 +1,6 @@
+---
+"@agentcommunity/aid": patch
+"@agentcommunity/aid-doctor": patch
+---
+
+Document canonical AID package links, production discovery examples, and the security contact for packed READMEs.

--- a/.github/workflows/ci-parity.yml
+++ b/.github/workflows/ci-parity.yml
@@ -39,3 +39,6 @@ jobs:
 
       - name: Run parity
         run: pnpm test:parity
+
+      - name: Verify advertised package claims and artifacts
+        run: pnpm verify:package-claims

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -106,12 +106,16 @@ jobs:
           }
 
           const textChecks = [
-            ['packages/aid-py/pyproject.toml', /license\s*=\s*\{\s*text\s*=\s*"MIT"\s*\}/],
+            ['packages/aid-py/pyproject.toml', /license\s*=\s*\{\s*file\s*=\s*"LICENSE"\s*\}/],
             ['packages/aid-rs/Cargo.toml', /^license\s*=\s*"MIT"/m],
           ];
           for (const [file, pattern] of textChecks) {
             const body = fs.readFileSync(file, 'utf8');
             if (!pattern.test(body)) missing.push(`${file}: missing MIT license metadata`);
+          }
+
+          if (fs.readFileSync('packages/aid-py/LICENSE', 'utf8') !== fs.readFileSync('LICENSE', 'utf8')) {
+            missing.push('packages/aid-py/LICENSE: must match the root LICENSE');
           }
 
           if (missing.length > 0) {

--- a/README.md
+++ b/README.md
@@ -120,9 +120,8 @@ pnpm add @agentcommunity/aid
 ```typescript
 import { discover, AidError } from '@agentcommunity/aid';
 
-const { record, ttl } = await discover('supabase.agentcommunity.org');
+const { record, ttl } = await discover('agentcommunity.org');
 console.log(`Found ${record.proto} agent at ${record.uri} (TTL: ${ttl}s)`);
-//=> Found mcp agent at https://api.supabase.com/mcp (TTL: 60s)
 ```
 
 **Browser (uses DNS-over-HTTPS):**
@@ -130,7 +129,7 @@ console.log(`Found ${record.proto} agent at ${record.uri} (TTL: ${ttl}s)`);
 ```typescript
 import { discover } from '@agentcommunity/aid/browser';
 
-const { record } = await discover('supabase.agentcommunity.org');
+const { record } = await discover('agentcommunity.org');
 console.log(`Found ${record.proto} agent at ${record.uri}`);
 ```
 
@@ -149,13 +148,11 @@ pip install aid-discovery
 from aid_py import discover, AidError
 
 try:
-    result = discover("supabase.agentcommunity.org")
-    print(f"Found {result.record.proto} agent at {result.record.uri}")
-    #=> Found mcp agent at https://api.supabase.com/mcp
+    record, ttl = discover("agentcommunity.org")
+    print(f"Found {record['proto']} agent at {record['uri']} (TTL: {ttl}s)")
 except AidError as e:
     print(f"AID Error ({e.code}): {e}")
 
-# NOTE: The Python package is currently published at https://pypi.org/project/aid-discovery/ and is not yet community-owned. Community transfer is planned for a future release.
 ```
 
 </details>
@@ -351,6 +348,7 @@ Thanks to our production-grade setup:
 ## Community & Support
 
 - For questions, ideas, and support, join our **[GitHub Discussions](https://github.com/orgs/agentcommunity/discussions)**.
+- To report a security issue privately, see [SECURITY.md](./SECURITY.md) or email [security@agentcommunity.org](mailto:security@agentcommunity.org).
 - Chat with us on **[Discord](https://discord.gg/S5XqVHrj)**.
 - To contribute, please see our **[Contributing Guide](./CONTRIBUTING.md)** and **[Code of Conduct](https://github.com/agentcommunity/.github/blob/main/CONTRIBUTING.md)**.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,13 @@
+# Security Policy
+
+## Report a vulnerability
+
+Please report suspected vulnerabilities privately to [security@agentcommunity.org](mailto:security@agentcommunity.org). Include enough detail to reproduce the issue safely, such as affected package versions, steps, and any proof of concept. Do not open a public issue for an unpatched vulnerability.
+
+We will acknowledge a report within five business days. After we validate it, we will share our assessment and planned next steps when we can do so safely. Response and remediation timing depend on severity, impact, and the information available in the report.
+
+## Scope
+
+This policy covers the AID packages published from this repository, including `@agentcommunity/aid`, `@agentcommunity/aid-doctor`, and `aid-discovery`, plus the public service at [aid.agentcommunity.org](https://aid.agentcommunity.org).
+
+For general usage questions or feature requests, use [GitHub Discussions](https://github.com/orgs/agentcommunity/discussions) instead.

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "docs:check": "node scripts/docs-check.mjs",
     "docs:export": "node scripts/docs-export.mjs",
     "docs:verify": "pnpm docs:check && pnpm docs:export && git diff --exit-code packages/docs/export-manifest.json packages/docs/export-manifest.sha256",
+    "verify:package-claims": "node scripts/verify-package-claims.mjs",
     "e2e": "turbo run e2e",
     "issues:spec12:enterprise": "node scripts/open-spec-1.2-enterprise-hardening-issues.mjs --apply",
     "changeset": "changeset",

--- a/packages/aid-doctor/README.md
+++ b/packages/aid-doctor/README.md
@@ -13,8 +13,9 @@ No more hunting through API docs. No more manual configuration. It's the zero-fr
 Built by the team at [agentcommunity.org](https://agentcommunity.org).
 
 - **Website**: [aid.agentcommunity.org](https://aid.agentcommunity.org)
-- **Docs**: [docs.agentcommunity.org/aid](https://docs.agentcommunity.org/aid)
-- **GitHub**: [github.com/agent-community/agent-identity-discovery](https://github.com/agent-community/agent-identity-discovery)
+- **Docs**: [aid.agentcommunity.org/docs](https://aid.agentcommunity.org/docs)
+- **GitHub**: [github.com/agentcommunity/agent-identity-discovery](https://github.com/agentcommunity/agent-identity-discovery)
+- **Security**: [security@agentcommunity.org](mailto:security@agentcommunity.org) ([policy](https://github.com/agentcommunity/agent-identity-discovery/blob/main/SECURITY.md))
 
 ---
 
@@ -30,10 +31,10 @@ pnpm add -D @agentcommunity/aid-doctor
 
 ```bash
 # Human-readable check
-aid-doctor check example.com
+aid-doctor check agentcommunity.org
 
 # JSON output (machine-readable)
-aid-doctor json example.com
+aid-doctor json agentcommunity.org
 ```
 
 ### Options

--- a/packages/aid-py/LICENSE
+++ b/packages/aid-py/LICENSE
@@ -1,0 +1,44 @@
+This project is dual-licensed under the MIT License and the Apache License 2.0.
+You may choose either license at your option.
+
+================================================================================
+MIT License
+================================================================================
+
+Copyright (c) 2025 .agent community
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+================================================================================
+Apache License, Version 2.0
+================================================================================
+
+Copyright (c) 2025 .agent community
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/packages/aid-py/README.md
+++ b/packages/aid-py/README.md
@@ -31,8 +31,8 @@ try:
     record, ttl = discover("agentcommunity.org")
 
     print(f"Protocol: {record['proto']}")          # "mcp"
-    print(f"URI: {record['uri']}")                 # "https://api.supabase.com/mcp"
-    print(f"Description: {record.get('desc')}")    # "Supabase MCP" (optional)
+    print(f"URI: {record['uri']}")                 # "https://agentcommunity.org/mcp"
+    print(f"Description: {record.get('desc')}")
     print(f"TTL: {ttl} seconds")
 
     # PKA domain-binding result (True only when an Ed25519 handshake
@@ -43,6 +43,10 @@ try:
 except AidError as e:
     print(f"Discovery failed: {e}")
 ```
+
+## Release note
+
+PyPI `aid-discovery` 2.1.1 is immutable. Before the corrected provenance-bearing PyPI publication, an owner must create the next `aid-discovery` patch version, coordinate PAGE's advertised version, and configure the PyPI Trusted Publisher. The release workflow uses `skip-existing`, so it cannot replace the existing 2.1.1 artifacts.
 
 ## API Reference
 

--- a/packages/aid-py/README.md
+++ b/packages/aid-py/README.md
@@ -10,8 +10,9 @@ AID enables you to discover AI agents by domain name using DNS TXT records. Type
 Built by the team at [agentcommunity.org](https://agentcommunity.org).
 
 - **Website**: [aid.agentcommunity.org](https://aid.agentcommunity.org)
-- **Docs**: [aid.agentcommunity.org](https://aid.agentcommunity.org)
+- **Docs**: [aid.agentcommunity.org/docs](https://aid.agentcommunity.org/docs)
 - **GitHub**: [github.com/agentcommunity/agent-identity-discovery](https://github.com/agentcommunity/agent-identity-discovery)
+- **Security**: [security@agentcommunity.org](mailto:security@agentcommunity.org) ([policy](https://github.com/agentcommunity/agent-identity-discovery/blob/main/SECURITY.md))
 
 ## Installation
 
@@ -27,7 +28,7 @@ from aid_py import discover, AidError
 try:
     # discover() returns a (record, ttl) tuple.
     # record is a dict (TypedDict); access fields by key.
-    record, ttl = discover("supabase.agentcommunity.org")
+    record, ttl = discover("agentcommunity.org")
 
     print(f"Protocol: {record['proto']}")          # "mcp"
     print(f"URI: {record['uri']}")                 # "https://api.supabase.com/mcp"

--- a/packages/aid-py/pyproject.toml
+++ b/packages/aid-py/pyproject.toml
@@ -8,7 +8,7 @@ version = "2.1.1"
 description = "Python library for Agent Identity & Discovery (AID), a DNS-based discovery protocol for AI agents"
 authors = [{ name = "Agent Community", email = "maintainers@agentcommunity.org" }]
 readme = "README.md"
-license = { text = "MIT" }
+license = { file = "LICENSE" }
 requires-python = ">=3.8"
 dependencies = ["dnspython>=2.6.0", "idna>=3.6"]
 keywords = ["agent", "discovery", "dns", "mcp", "a2a", "ai", "aid", "txt-record"]
@@ -31,10 +31,13 @@ classifiers = [
 [project.urls]
 Homepage = "https://aid.agentcommunity.org"
 Repository = "https://github.com/agentcommunity/agent-identity-discovery"
-Documentation = "https://aid.agentcommunity.org"
+Documentation = "https://aid.agentcommunity.org/docs"
 "Agent Community" = "https://agentcommunity.org/developers"
 
 [project.optional-dependencies]
 dev = ["pytest>=8"]
 # Preferred PKA backend (security-focused). Install to enable Ed25519 verification.
 pka = ["cryptography>=42"]
+
+[tool.setuptools.data-files]
+"share/doc/aid-discovery" = ["README.md"]

--- a/packages/aid/LICENSE
+++ b/packages/aid/LICENSE
@@ -1,0 +1,44 @@
+This project is dual-licensed under the MIT License and the Apache License 2.0.
+You may choose either license at your option.
+
+================================================================================
+MIT License
+================================================================================
+
+Copyright (c) 2025 .agent community
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+================================================================================
+Apache License, Version 2.0
+================================================================================
+
+Copyright (c) 2025 .agent community
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/packages/aid/README.md
+++ b/packages/aid/README.md
@@ -13,8 +13,9 @@ No more hunting through API docs. No more manual configuration. It's the zero-fr
 Built by the team at [agentcommunity.org](https://agentcommunity.org).
 
 - **Website**: [aid.agentcommunity.org](https://aid.agentcommunity.org)
-- **Docs**: [aid.agentcommunity.org](https://aid.agentcommunity.org)
+- **Docs**: [aid.agentcommunity.org/docs](https://aid.agentcommunity.org/docs)
 - **GitHub**: [github.com/agentcommunity/agent-identity-discovery](https://github.com/agentcommunity/agent-identity-discovery)
+- **Security**: [security@agentcommunity.org](mailto:security@agentcommunity.org) ([policy](https://github.com/agentcommunity/agent-identity-discovery/blob/main/SECURITY.md))
 
 ## Install
 
@@ -32,7 +33,7 @@ yarn add @agentcommunity/aid
 import { discover, AidError } from '@agentcommunity/aid';
 
 try {
-  const { record, ttl, queryName } = await discover('example.com');
+  const { record, ttl, queryName } = await discover('agentcommunity.org');
   console.log('Found', record.proto, 'at', record.uri, 'TTL:', ttl, 'query:', queryName);
 } catch (e) {
   if (e instanceof AidError) {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -25,7 +25,7 @@
     "start": "next start",
     "lint": "pnpm -w exec eslint --max-warnings 0 packages/web/src packages/web/next.config.js packages/web/postcss.config.js packages/web/tailwind.config.js packages/web/vitest.config.ts",
     "type-check": "tsc --noEmit",
-    "test": "vitest run",
+    "test": "pnpm gen:content && vitest run",
     "test:watch": "vitest",
     "test:ui": "vitest --ui"
   },

--- a/scripts/package-claim-archive.mjs
+++ b/scripts/package-claim-archive.mjs
@@ -1,0 +1,18 @@
+import { execFileSync } from 'node:child_process';
+
+export function readPythonWheelLicense(archivePath) {
+  const script = [
+    'import sys, zipfile',
+    'archive = sys.argv[1]',
+    'suffixes = (".dist-info/LICENSE", ".dist-info/licenses/LICENSE")',
+    'with zipfile.ZipFile(archive) as container:',
+    '    matches = [name for name in container.namelist() if name.endswith(suffixes)]',
+    '    if len(matches) != 1:',
+    '        raise SystemExit(f"expected exactly one supported wheel license entry, found {matches}")',
+    '    sys.stdout.buffer.write(container.read(matches[0]))',
+  ].join('\n');
+  return execFileSync('python3', ['-c', script, archivePath], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+}

--- a/scripts/package-claim-url.mjs
+++ b/scripts/package-claim-url.mjs
@@ -1,0 +1,41 @@
+import { URL } from 'node:url';
+
+function urlsIn(contents) {
+  return contents.match(/https:\/\/[^\s<>'"`\])}]+/g) ?? [];
+}
+
+function parseUrl(candidate) {
+  try {
+    return new URL(candidate);
+  } catch {
+    return null;
+  }
+}
+
+export function containsExactUrl(contents, expectedUrl) {
+  const expected = new URL(expectedUrl);
+  return urlsIn(contents).some(function (candidate) {
+    const parsed = parseUrl(candidate);
+    return parsed !== null
+      && parsed.protocol === expected.protocol
+      && parsed.username === ''
+      && parsed.password === ''
+      && parsed.hostname === expected.hostname
+      && parsed.port === expected.port
+      && parsed.pathname === expected.pathname
+      && parsed.search === expected.search
+      && parsed.hash === expected.hash;
+  });
+}
+
+export function containsExactHost(contents, expectedHost) {
+  return urlsIn(contents).some(function (candidate) {
+    const parsed = parseUrl(candidate);
+    return parsed !== null
+      && parsed.protocol === 'https:'
+      && parsed.username === ''
+      && parsed.password === ''
+      && parsed.hostname === expectedHost
+      && parsed.port === '';
+  });
+}

--- a/scripts/package-claim-url.test.mjs
+++ b/scripts/package-claim-url.test.mjs
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { containsExactHost, containsExactUrl } from './package-claim-url.mjs';
+
+test('accepts an exact canonical URL in package provenance text', () => {
+  assert.equal(
+    containsExactUrl('Repository: https://github.com/agentcommunity/agent-identity-discovery', 'https://github.com/agentcommunity/agent-identity-discovery'),
+    true,
+  );
+});
+
+test('rejects prefixed and suffixed attacker URLs in package provenance text', () => {
+  const expected = 'https://github.com/agentcommunity/agent-identity-discovery';
+  for (const attackerUrl of [
+    'https://evil.example/https://github.com/agentcommunity/agent-identity-discovery',
+    'https://github.com/agentcommunity/agent-identity-discovery.evil.example',
+    'https://github.com/agentcommunity/agent-identity-discovery?redirect=https://evil.example',
+  ]) {
+    assert.equal(containsExactUrl(`Repository: ${attackerUrl}`, expected), false);
+  }
+});
+
+test('accepts only an exact agentcommunity.org host', () => {
+  assert.equal(containsExactHost('Endpoint: https://agentcommunity.org/mcp', 'agentcommunity.org'), true);
+  for (const attackerUrl of [
+    'https://evil.example/agentcommunity.org/mcp',
+    'https://agentcommunity.org.evil.example/mcp',
+    'https://notagentcommunity.org/mcp',
+  ]) {
+    assert.equal(containsExactHost(`Endpoint: ${attackerUrl}`, 'agentcommunity.org'), false);
+  }
+});

--- a/scripts/package-claim-workspace.mjs
+++ b/scripts/package-claim-workspace.mjs
@@ -1,0 +1,19 @@
+import { cpSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+export function copyPackageWorkspace({ checkout, temporaryRoot, packageNames }) {
+  const temporaryPackages = join(temporaryRoot, 'packages');
+  mkdirSync(temporaryPackages, { recursive: true });
+  for (const packageName of packageNames) {
+    const source = join(checkout, 'packages', packageName);
+    const destination = join(temporaryPackages, packageName);
+    cpSync(source, destination, {
+      recursive: true,
+      verbatimSymlinks: true,
+      filter(path) {
+        return path !== join(source, 'dist');
+      },
+    });
+  }
+  return temporaryPackages;
+}

--- a/scripts/package-claim-workspace.test.mjs
+++ b/scripts/package-claim-workspace.test.mjs
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict';
+import { existsSync, mkdtempSync, mkdirSync, realpathSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import { copyPackageWorkspace } from './package-claim-workspace.mjs';
+
+test('copied workspace dependencies resolve only inside the temporary workspace', () => {
+  const fixtureRoot = mkdtempSync(join(tmpdir(), 'aid-package-workspace-fixture-'));
+  const checkout = join(fixtureRoot, 'checkout');
+  const temporaryRoot = join(fixtureRoot, 'temporary');
+  const packageNames = ['aid', 'aid-engine', 'aid-doctor'];
+  try {
+    for (const packageName of packageNames) {
+      mkdirSync(join(checkout, 'packages', packageName, 'node_modules', '@agentcommunity'), { recursive: true });
+      writeFileSync(join(checkout, 'packages', packageName, 'package.json'), JSON.stringify({ name: packageName }));
+    }
+    mkdirSync(join(checkout, 'packages', 'aid', 'dist'), { recursive: true });
+    writeFileSync(join(checkout, 'packages', 'aid', 'dist', 'stale.js'), 'throw new Error("checkout dist consumed");\n');
+    symlinkSync('../../../aid', join(checkout, 'packages', 'aid-engine', 'node_modules', '@agentcommunity', 'aid'));
+    symlinkSync('../../../aid', join(checkout, 'packages', 'aid-doctor', 'node_modules', '@agentcommunity', 'aid'));
+    symlinkSync('../../../aid-engine', join(checkout, 'packages', 'aid-doctor', 'node_modules', '@agentcommunity', 'aid-engine'));
+
+    const temporaryPackages = copyPackageWorkspace({ checkout, temporaryRoot, packageNames });
+    const canonicalCheckout = realpathSync(checkout);
+    for (const [packageName, dependencyName] of [
+      ['aid-engine', 'aid'],
+      ['aid-doctor', 'aid'],
+      ['aid-doctor', 'aid-engine'],
+    ]) {
+      const resolved = realpathSync(join(temporaryPackages, packageName, 'node_modules', '@agentcommunity', dependencyName));
+      assert.equal(resolved, realpathSync(join(temporaryPackages, dependencyName)));
+      assert.equal(resolved.startsWith(canonicalCheckout), false);
+    }
+    assert.equal(existsSync(join(temporaryPackages, 'aid', 'dist')), false);
+  } finally {
+    rmSync(fixtureRoot, { recursive: true, force: true });
+  }
+});

--- a/scripts/verify-package-claims.mjs
+++ b/scripts/verify-package-claims.mjs
@@ -3,6 +3,7 @@ import { cpSync, existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, sym
 import { devNull, tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { readPythonWheelLicense } from './package-claim-archive.mjs';
+import { containsExactHost, containsExactUrl } from './package-claim-url.mjs';
 
 const repoRoot = resolve(import.meta.dirname, '..');
 const temporaryRoot = mkdtempSync(join(tmpdir(), 'aid-package-claims-'));
@@ -69,13 +70,13 @@ function capture(command, args, options = {}) {
 }
 
 function assertReadme(contents, label, packageName) {
-  expect(contents.includes(repository), `${label} must link to ${repository}`);
-  expect(contents.includes(homepage), `${label} must link to ${homepage}`);
-  expect(contents.includes(docs), `${label} must link to ${docs}`);
+  expect(containsExactUrl(contents, repository), `${label} must link to ${repository}`);
+  expect(containsExactUrl(contents, homepage), `${label} must link to ${homepage}`);
+  expect(containsExactUrl(contents, docs), `${label} must link to ${docs}`);
   expect(contents.includes(securityContact), `${label} must include ${securityContact}`);
-  expect(contents.includes(securityPolicy), `${label} must link to ${securityPolicy}`);
+  expect(containsExactUrl(contents, securityPolicy), `${label} must link to ${securityPolicy}`);
   expect(contents.includes(packageName), `${label} must use the exact package name ${packageName}`);
-  expect(contents.includes(productionDomain), `${label} must include a ${productionDomain} production example`);
+  expect(containsExactHost(contents, productionDomain), `${label} must include a ${productionDomain} production example`);
 }
 
 function assertPackagedReadme(contents, label, packageName) {
@@ -101,6 +102,7 @@ function assertPackagedMetadata(metadata, label, packageName) {
 }
 
 function assertPythonMetadata(metadata, label) {
+  const metadataLines = new Set(metadata.split(/\r?\n/));
   for (const expectedLine of [
     'Name: aid-discovery',
     'Version: 2.1.1',
@@ -109,7 +111,7 @@ function assertPythonMetadata(metadata, label) {
     `Project-URL: Documentation, ${docs}`,
     'License-File: LICENSE',
   ]) {
-    expect(metadata.includes(expectedLine), `${label} must include ${expectedLine}`);
+    expect(metadataLines.has(expectedLine), `${label} must include ${expectedLine}`);
   }
 }
 
@@ -180,13 +182,13 @@ function verifySourceClaims() {
   const rootReadme = read('README.md');
   expect(existsSync(join(repoRoot, 'SECURITY.md')), 'root SECURITY.md must exist');
   expect(read('SECURITY.md').includes(securityContact), 'SECURITY.md must name the security contact');
-  expect(rootReadme.includes(repository), 'README.md must link to the canonical repository');
-  expect(rootReadme.includes(homepage), 'README.md must link to the canonical product home');
-  expect(rootReadme.includes(docs), 'README.md must link to the canonical docs');
+  expect(containsExactUrl(rootReadme, repository), 'README.md must link to the canonical repository');
+  expect(containsExactUrl(rootReadme, homepage), 'README.md must link to the canonical product home');
+  expect(containsExactUrl(rootReadme, docs), 'README.md must link to the canonical docs');
   expect(rootReadme.includes(securityContact), 'README.md must include the security contact');
   expect(rootReadme.includes('SECURITY.md'), 'README.md must link to SECURITY.md');
   expect(!rootReadme.includes('not yet community-owned'), 'README.md must not claim aid-discovery is not community-owned');
-  expect(rootReadme.includes(productionDomain), 'README.md must include an agentcommunity.org production example');
+  expect(containsExactHost(rootReadme, productionDomain), 'README.md must include an agentcommunity.org production example');
 
   assertNpmMetadata(readJson('packages/aid/package.json'), 'packages/aid/package.json', '@agentcommunity/aid');
   assertNpmMetadata(readJson('packages/aid-doctor/package.json'), 'packages/aid-doctor/package.json', '@agentcommunity/aid-doctor');
@@ -194,14 +196,14 @@ function verifySourceClaims() {
   assertReadme(read('packages/aid-doctor/README.md'), 'packages/aid-doctor/README.md', '@agentcommunity/aid-doctor');
   const pythonReadme = read('packages/aid-py/README.md');
   assertReadme(pythonReadme, 'packages/aid-py/README.md', 'aid-discovery');
-  expect(pythonReadme.includes(expectedProductionUri), 'Python README must document the live agentcommunity.org endpoint');
+  expect(containsExactUrl(pythonReadme, expectedProductionUri), 'Python README must document the live agentcommunity.org endpoint');
 
   const pythonProject = read('packages/aid-py/pyproject.toml');
   expect(pythonProject.includes('name = "aid-discovery"'), 'Python project name must be aid-discovery');
   expect(pythonProject.includes('version = "2.1.1"'), 'Python version must be 2.1.1');
   expect(pythonProject.includes('requires-python = ">=3.8"'), 'Python must keep >=3.8 support');
   expect(pythonProject.includes('license = { file = "LICENSE" }'), 'Python must use the package-local LICENSE metadata');
-  expect(pythonProject.includes(`Documentation = "${docs}"`), 'Python documentation URL must be canonical');
+  expect(containsExactUrl(pythonProject, docs), 'Python documentation URL must be canonical');
   expect(read('packages/aid-py/LICENSE') === read('LICENSE'), 'Python LICENSE must match root LICENSE');
 
   const webPackage = readJson('packages/web/package.json');

--- a/scripts/verify-package-claims.mjs
+++ b/scripts/verify-package-claims.mjs
@@ -2,6 +2,7 @@ import { execFileSync } from 'node:child_process';
 import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { devNull, tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
+import { readPythonWheelLicense } from './package-claim-archive.mjs';
 
 const repoRoot = resolve(import.meta.dirname, '..');
 const temporaryRoot = mkdtempSync(join(tmpdir(), 'aid-package-claims-'));
@@ -249,14 +250,13 @@ function verifyArtifacts() {
   const sdist = findArchive(pythonOutput, '.tar.gz');
   const wheel = findArchive(pythonOutput, '.whl');
   const pythonLicense = read('packages/aid-py/LICENSE');
-  for (const [archive, label, readmeSuffix, licenseSuffix, metadataSuffix] of [
-    [sdist, 'aid-discovery sdist', '/README.md', '/LICENSE', 'aid_discovery-2.1.1/PKG-INFO'],
-    [wheel, 'aid-discovery wheel', '/README.md', 'dist-info/licenses/LICENSE', 'dist-info/METADATA'],
-  ]) {
-    assertPackagedReadme(readPythonArchiveEntry(archive, readmeSuffix), label, 'aid-discovery');
-    assertPackagedLicense(readPythonArchiveEntry(archive, licenseSuffix), label, pythonLicense);
-    assertPythonMetadata(readPythonArchiveEntry(archive, metadataSuffix), label);
-  }
+  assertPackagedReadme(readPythonArchiveEntry(sdist, '/README.md'), 'aid-discovery sdist', 'aid-discovery');
+  assertPackagedLicense(readPythonArchiveEntry(sdist, '/LICENSE'), 'aid-discovery sdist', pythonLicense);
+  assertPythonMetadata(readPythonArchiveEntry(sdist, 'aid_discovery-2.1.1/PKG-INFO'), 'aid-discovery sdist');
+
+  assertPackagedReadme(readPythonArchiveEntry(wheel, '/README.md'), 'aid-discovery wheel', 'aid-discovery');
+  assertPackagedLicense(readPythonWheelLicense(wheel), 'aid-discovery wheel', pythonLicense);
+  assertPythonMetadata(readPythonArchiveEntry(wheel, 'dist-info/METADATA'), 'aid-discovery wheel');
 
   run('python3', ['-m', 'venv', pythonInstallEnvironment]);
   const installPython = join(pythonInstallEnvironment, 'bin', 'python');

--- a/scripts/verify-package-claims.mjs
+++ b/scripts/verify-package-claims.mjs
@@ -4,6 +4,7 @@ import { devNull, tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { readPythonWheelLicense } from './package-claim-archive.mjs';
 import { containsExactHost, containsExactUrl } from './package-claim-url.mjs';
+import { copyPackageWorkspace } from './package-claim-workspace.mjs';
 
 const repoRoot = resolve(import.meta.dirname, '..');
 const temporaryRoot = mkdtempSync(join(tmpdir(), 'aid-package-claims-'));
@@ -153,23 +154,11 @@ function prepareTemporaryConfig() {
 }
 
 function copyNpmPackageSources() {
-  const temporaryPackages = join(temporaryRoot, 'packages');
-  run('mkdir', ['-p', temporaryPackages]);
   for (const file of ['package.json', 'pnpm-lock.yaml', 'pnpm-workspace.yaml', 'tsconfig.json', 'tsup.config.base.ts', 'turbo.json']) {
     cpSync(join(repoRoot, file), join(temporaryRoot, file));
   }
   symlinkSync(join(repoRoot, 'node_modules'), join(temporaryRoot, 'node_modules'), 'dir');
-  for (const packageName of npmPackages) {
-    const source = join(repoRoot, 'packages', packageName);
-    const destination = join(temporaryPackages, packageName);
-    cpSync(source, destination, {
-      recursive: true,
-      filter(path) {
-        return path !== join(source, 'dist');
-      },
-    });
-  }
-  return temporaryPackages;
+  return copyPackageWorkspace({ checkout: repoRoot, temporaryRoot, packageNames: npmPackages });
 }
 
 function cleanup() {

--- a/scripts/verify-package-claims.mjs
+++ b/scripts/verify-package-claims.mjs
@@ -1,6 +1,6 @@
 import { execFileSync } from 'node:child_process';
-import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { devNull, tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 
 const repoRoot = resolve(import.meta.dirname, '..');
@@ -9,7 +9,17 @@ const repository = 'https://github.com/agentcommunity/agent-identity-discovery';
 const homepage = 'https://aid.agentcommunity.org';
 const docs = 'https://aid.agentcommunity.org/docs';
 const securityContact = 'security@agentcommunity.org';
+const securityPolicy = `${repository}/blob/main/SECURITY.md`;
 const productionDomain = 'agentcommunity.org';
+const expectedProductionUri = 'https://agentcommunity.org/mcp';
+const checkoutOutputs = [
+  'packages/aid/dist',
+  'packages/aid-engine/dist',
+  'packages/aid-doctor/dist',
+];
+
+let cleaned = false;
+let verifierCheckoutOutputs = [];
 
 function fail(message) {
   throw new Error(`Package claim verification failed: ${message}`);
@@ -27,17 +37,11 @@ function readJson(relativePath) {
   return JSON.parse(read(relativePath));
 }
 
-function run(command, args, options = {}) {
-  execFileSync(command, args, {
-    cwd: repoRoot,
-    stdio: 'inherit',
-    env: registrySafeEnvironment(options.env),
-    ...options,
-  });
-}
-
-function registrySafeEnvironment(overrides) {
+function registrySafeEnvironment() {
   const environment = { ...process.env };
+  for (const name of Object.keys(environment)) {
+    if (name.startsWith('PIP_')) delete environment[name];
+  }
   for (const name of ['NPM_TOKEN', 'NODE_AUTH_TOKEN', 'PYPI_TOKEN', 'TWINE_PASSWORD', 'TWINE_USERNAME']) {
     delete environment[name];
   }
@@ -45,56 +49,126 @@ function registrySafeEnvironment(overrides) {
   return {
     ...environment,
     NPM_CONFIG_USERCONFIG: join(temporaryRoot, 'npmrc'),
-    PIP_CONFIG_FILE: join(temporaryRoot, 'pip.conf'),
-    ...overrides,
+    PIP_CONFIG_FILE: devNull,
   };
 }
 
-function assertReadme(relativePath, packageName) {
-  const contents = read(relativePath);
-  expect(contents.includes(repository), `${relativePath} must link to ${repository}`);
-  expect(contents.includes(homepage), `${relativePath} must link to ${homepage}`);
-  expect(contents.includes(docs), `${relativePath} must link to ${docs}`);
-  expect(contents.includes(securityContact), `${relativePath} must include ${securityContact}`);
-  expect(contents.includes('SECURITY.md'), `${relativePath} must link to SECURITY.md`);
-  expect(contents.includes(packageName), `${relativePath} must use the exact package name ${packageName}`);
-  expect(contents.includes(productionDomain), `${relativePath} must include a ${productionDomain} production example`);
+function run(command, args, options = {}) {
+  const { env: _ignoredEnvironment, ...runOptions } = options;
+  execFileSync(command, args, {
+    cwd: repoRoot,
+    stdio: 'inherit',
+    ...runOptions,
+    env: registrySafeEnvironment(),
+  });
 }
 
-function assertNpmMetadata(relativePath, packageName) {
-  const manifest = readJson(relativePath);
-  expect(manifest.name === packageName, `${relativePath} name must be ${packageName}`);
-  expect(manifest.version === '2.1.1', `${relativePath} version must be 2.1.1`);
-  expect(manifest.repository?.url === repository, `${relativePath} repository must be canonical`);
-  expect(manifest.homepage === homepage, `${relativePath} homepage must be canonical`);
-  expect(manifest.bugs?.url === `${repository}/issues`, `${relativePath} bugs URL must be canonical`);
-  expect(manifest.license === 'MIT', `${relativePath} license must be MIT`);
-  expect(manifest.engines?.node === '>=18.17', `${relativePath} node engine must remain >=18.17`);
+function capture(command, args, options = {}) {
+  const { env: _ignoredEnvironment, ...runOptions } = options;
+  return execFileSync(command, args, {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    ...runOptions,
+    env: registrySafeEnvironment(),
+  });
 }
 
-function assertTarEntries(archivePath, expectedEntries) {
-  const entries = execFileSync('tar', ['-tzf', archivePath], { encoding: 'utf8' });
-  for (const entry of expectedEntries) {
-    expect(entries.split('\n').includes(entry), `${archivePath} must contain ${entry}`);
+function assertReadme(contents, label, packageName) {
+  expect(contents.includes(repository), `${label} must link to ${repository}`);
+  expect(contents.includes(homepage), `${label} must link to ${homepage}`);
+  expect(contents.includes(docs), `${label} must link to ${docs}`);
+  expect(contents.includes(securityContact), `${label} must include ${securityContact}`);
+  expect(contents.includes(securityPolicy), `${label} must link to ${securityPolicy}`);
+  expect(contents.includes(packageName), `${label} must use the exact package name ${packageName}`);
+  expect(contents.includes(productionDomain), `${label} must include a ${productionDomain} production example`);
+}
+
+function assertPackagedReadme(contents, label, packageName) {
+  assertReadme(contents, `${label} README`, packageName);
+}
+
+function assertPackagedLicense(contents, label, expectedLicense) {
+  expect(contents === expectedLicense, `${label} LICENSE must match its package-local license bytes`);
+}
+
+function assertNpmMetadata(manifest, label, packageName) {
+  expect(manifest.name === packageName, `${label} name must be ${packageName}`);
+  expect(manifest.version === '2.1.1', `${label} version must be 2.1.1`);
+  expect(manifest.repository?.url === repository, `${label} repository must be canonical`);
+  expect(manifest.homepage === homepage, `${label} homepage must be canonical`);
+  expect(manifest.bugs?.url === `${repository}/issues`, `${label} bugs URL must be canonical`);
+  expect(manifest.license === 'MIT', `${label} license must be MIT`);
+  expect(manifest.engines?.node === '>=18.17', `${label} node engine must remain >=18.17`);
+}
+
+function assertPackagedMetadata(metadata, label, packageName) {
+  assertNpmMetadata(metadata, `${label} package metadata`, packageName);
+}
+
+function assertPythonMetadata(metadata, label) {
+  for (const expectedLine of [
+    'Name: aid-discovery',
+    'Version: 2.1.1',
+    `Project-URL: Homepage, ${homepage}`,
+    `Project-URL: Repository, ${repository}`,
+    `Project-URL: Documentation, ${docs}`,
+    'License-File: LICENSE',
+  ]) {
+    expect(metadata.includes(expectedLine), `${label} must include ${expectedLine}`);
   }
 }
 
-function assertPythonArchiveEntries(archivePath, expectedSuffixes) {
+function readTarEntry(archivePath, entry) {
+  return execFileSync('tar', ['-xOzf', archivePath, entry], { encoding: 'utf8' });
+}
+
+function readPythonArchiveEntry(archivePath, suffix) {
   const script = [
     'import pathlib, sys, tarfile, zipfile',
     'archive = pathlib.Path(sys.argv[1])',
-    'names = tarfile.open(archive).getnames() if archive.suffix == ".gz" else zipfile.ZipFile(archive).namelist()',
-    'for suffix in sys.argv[2:]:',
-    '    if not any(name.endswith(suffix) for name in names):',
-    '        raise SystemExit(f"missing {suffix} from {archive}")',
+    'suffix = sys.argv[2]',
+    'if archive.suffix == ".gz":',
+    '    with tarfile.open(archive) as container:',
+    '        names = container.getnames()',
+    '        matches = [name for name in names if name.endswith(suffix)]',
+    '        if len(matches) != 1: raise SystemExit(f"expected one {suffix}, found {matches}")',
+    '        source = container.extractfile(matches[0])',
+    '        if source is None: raise SystemExit(f"could not read {matches[0]}")',
+    '        sys.stdout.buffer.write(source.read())',
+    'else:',
+    '    with zipfile.ZipFile(archive) as container:',
+    '        names = container.namelist()',
+    '        matches = [name for name in names if name.endswith(suffix)]',
+    '        if len(matches) != 1: raise SystemExit(f"expected one {suffix}, found {matches}")',
+    '        sys.stdout.buffer.write(container.read(matches[0]))',
   ].join('\n');
-  run('python3', ['-c', script, archivePath, ...expectedSuffixes]);
+  return capture('python3', ['-c', script, archivePath, suffix]);
 }
 
 function findArchive(directory, suffix) {
   const match = readdirSync(directory).find((entry) => entry.endsWith(suffix));
   expect(match, `expected a ${suffix} artifact in ${directory}`);
   return join(directory, match);
+}
+
+function prepareTemporaryConfig() {
+  writeFileSync(join(temporaryRoot, 'npmrc'), '');
+}
+
+function copyNpmPackageSources() {
+  for (const output of checkoutOutputs) {
+    expect(!existsSync(join(repoRoot, output)), `refusing to overwrite pre-existing ${output}`);
+  }
+  verifierCheckoutOutputs = checkoutOutputs;
+}
+
+function cleanup() {
+  if (cleaned) return;
+  cleaned = true;
+  for (const output of verifierCheckoutOutputs) {
+    rmSync(join(repoRoot, output), { recursive: true, force: true });
+  }
+  rmSync(temporaryRoot, { recursive: true, force: true });
 }
 
 function verifySourceClaims() {
@@ -109,11 +183,13 @@ function verifySourceClaims() {
   expect(!rootReadme.includes('not yet community-owned'), 'README.md must not claim aid-discovery is not community-owned');
   expect(rootReadme.includes(productionDomain), 'README.md must include an agentcommunity.org production example');
 
-  assertNpmMetadata('packages/aid/package.json', '@agentcommunity/aid');
-  assertNpmMetadata('packages/aid-doctor/package.json', '@agentcommunity/aid-doctor');
-  assertReadme('packages/aid/README.md', '@agentcommunity/aid');
-  assertReadme('packages/aid-doctor/README.md', '@agentcommunity/aid-doctor');
-  assertReadme('packages/aid-py/README.md', 'aid-discovery');
+  assertNpmMetadata(readJson('packages/aid/package.json'), 'packages/aid/package.json', '@agentcommunity/aid');
+  assertNpmMetadata(readJson('packages/aid-doctor/package.json'), 'packages/aid-doctor/package.json', '@agentcommunity/aid-doctor');
+  assertReadme(read('packages/aid/README.md'), 'packages/aid/README.md', '@agentcommunity/aid');
+  assertReadme(read('packages/aid-doctor/README.md'), 'packages/aid-doctor/README.md', '@agentcommunity/aid-doctor');
+  const pythonReadme = read('packages/aid-py/README.md');
+  assertReadme(pythonReadme, 'packages/aid-py/README.md', 'aid-discovery');
+  expect(pythonReadme.includes(expectedProductionUri), 'Python README must document the live agentcommunity.org endpoint');
 
   const pythonProject = read('packages/aid-py/pyproject.toml');
   expect(pythonProject.includes('name = "aid-discovery"'), 'Python project name must be aid-discovery');
@@ -134,6 +210,7 @@ function verifyArtifacts() {
   const pythonBuildEnvironment = join(temporaryRoot, 'python-build');
   const pythonInstallEnvironment = join(temporaryRoot, 'python-install');
   run('mkdir', ['-p', npmOutput, pythonOutput]);
+  copyNpmPackageSources();
   run('pnpm', ['-C', 'packages/aid', 'build']);
   run('pnpm', ['-C', 'packages/aid-engine', 'build']);
   run('pnpm', ['-C', 'packages/aid-doctor', 'build']);
@@ -142,8 +219,16 @@ function verifyArtifacts() {
 
   const aidArchive = findArchive(npmOutput, 'agentcommunity-aid-2.1.1.tgz');
   const doctorArchive = findArchive(npmOutput, 'agentcommunity-aid-doctor-2.1.1.tgz');
-  assertTarEntries(aidArchive, ['package/README.md', 'package/LICENSE']);
-  assertTarEntries(doctorArchive, ['package/README.md', 'package/LICENSE']);
+  const npmArtifacts = [
+    [aidArchive, '@agentcommunity/aid', 'packages/aid/LICENSE'],
+    [doctorArchive, '@agentcommunity/aid-doctor', 'packages/aid-doctor/LICENSE'],
+  ];
+  for (const [archive, packageName, licensePath] of npmArtifacts) {
+    const label = `${packageName} tarball`;
+    assertPackagedReadme(readTarEntry(archive, 'package/README.md'), label, packageName);
+    assertPackagedLicense(readTarEntry(archive, 'package/LICENSE'), label, read(licensePath));
+    assertPackagedMetadata(JSON.parse(readTarEntry(archive, 'package/package.json')), label, packageName);
+  }
 
   const aidInstall = join(temporaryRoot, 'npm-aid');
   const doctorInstall = join(temporaryRoot, 'npm-doctor');
@@ -159,26 +244,44 @@ function verifyArtifacts() {
   run('python3', ['-m', 'venv', pythonBuildEnvironment]);
   const buildPython = join(pythonBuildEnvironment, 'bin', 'python');
   run('cp', ['-R', 'packages/aid-py', pythonSource]);
-  run(buildPython, ['-m', 'pip', 'install', '--disable-pip-version-check', 'build']);
+  run(buildPython, ['-m', 'pip', '--isolated', 'install', '--disable-pip-version-check', 'build']);
   run(buildPython, ['-m', 'build', '--sdist', '--wheel', '--outdir', pythonOutput, pythonSource]);
   const sdist = findArchive(pythonOutput, '.tar.gz');
   const wheel = findArchive(pythonOutput, '.whl');
-  assertPythonArchiveEntries(sdist, ['LICENSE', 'README.md']);
-  assertPythonArchiveEntries(wheel, ['LICENSE', 'README.md']);
+  const pythonLicense = read('packages/aid-py/LICENSE');
+  for (const [archive, label, readmeSuffix, licenseSuffix, metadataSuffix] of [
+    [sdist, 'aid-discovery sdist', '/README.md', '/LICENSE', 'aid_discovery-2.1.1/PKG-INFO'],
+    [wheel, 'aid-discovery wheel', '/README.md', 'dist-info/licenses/LICENSE', 'dist-info/METADATA'],
+  ]) {
+    assertPackagedReadme(readPythonArchiveEntry(archive, readmeSuffix), label, 'aid-discovery');
+    assertPackagedLicense(readPythonArchiveEntry(archive, licenseSuffix), label, pythonLicense);
+    assertPythonMetadata(readPythonArchiveEntry(archive, metadataSuffix), label);
+  }
 
   run('python3', ['-m', 'venv', pythonInstallEnvironment]);
   const installPython = join(pythonInstallEnvironment, 'bin', 'python');
-  run(installPython, ['-m', 'pip', 'install', '--disable-pip-version-check', wheel]);
-  run(installPython, [
+  run(installPython, ['-m', 'pip', '--isolated', 'install', '--disable-pip-version-check', wheel]);
+  const livePythonUri = capture(installPython, [
     '-c',
-    `from aid_py import discover; record, _ = discover('${productionDomain}'); assert record['uri']`,
-  ]);
+    `from aid_py import discover; record, _ = discover('${productionDomain}'); print(record['uri'])`,
+  ]).trim();
+  expect(livePythonUri === expectedProductionUri, `Python discovery must return ${expectedProductionUri}, received ${livePythonUri}`);
 }
 
+process.on('SIGINT', () => {
+  cleanup();
+  process.exit(130);
+});
+process.on('SIGTERM', () => {
+  cleanup();
+  process.exit(143);
+});
+
 try {
+  prepareTemporaryConfig();
   verifySourceClaims();
   verifyArtifacts();
   console.log('Package claims and artifacts verified.');
 } finally {
-  rmSync(temporaryRoot, { recursive: true, force: true });
+  cleanup();
 }

--- a/scripts/verify-package-claims.mjs
+++ b/scripts/verify-package-claims.mjs
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process';
-import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { cpSync, existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { devNull, tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { readPythonWheelLicense } from './package-claim-archive.mjs';
@@ -13,15 +13,9 @@ const securityContact = 'security@agentcommunity.org';
 const securityPolicy = `${repository}/blob/main/SECURITY.md`;
 const productionDomain = 'agentcommunity.org';
 const expectedProductionUri = 'https://agentcommunity.org/mcp';
-const checkoutOutputs = [
-  'packages/aid/dist',
-  'packages/aid-engine/dist',
-  'packages/aid-doctor/dist',
-];
+const npmPackages = ['aid', 'aid-engine', 'aid-doctor'];
 
 let cleaned = false;
-let verifierCheckoutOutputs = [];
-
 function fail(message) {
   throw new Error(`Package claim verification failed: ${message}`);
 }
@@ -157,18 +151,28 @@ function prepareTemporaryConfig() {
 }
 
 function copyNpmPackageSources() {
-  for (const output of checkoutOutputs) {
-    expect(!existsSync(join(repoRoot, output)), `refusing to overwrite pre-existing ${output}`);
+  const temporaryPackages = join(temporaryRoot, 'packages');
+  run('mkdir', ['-p', temporaryPackages]);
+  for (const file of ['package.json', 'pnpm-lock.yaml', 'pnpm-workspace.yaml', 'tsconfig.json', 'tsup.config.base.ts', 'turbo.json']) {
+    cpSync(join(repoRoot, file), join(temporaryRoot, file));
   }
-  verifierCheckoutOutputs = checkoutOutputs;
+  symlinkSync(join(repoRoot, 'node_modules'), join(temporaryRoot, 'node_modules'), 'dir');
+  for (const packageName of npmPackages) {
+    const source = join(repoRoot, 'packages', packageName);
+    const destination = join(temporaryPackages, packageName);
+    cpSync(source, destination, {
+      recursive: true,
+      filter(path) {
+        return path !== join(source, 'dist');
+      },
+    });
+  }
+  return temporaryPackages;
 }
 
 function cleanup() {
   if (cleaned) return;
   cleaned = true;
-  for (const output of verifierCheckoutOutputs) {
-    rmSync(join(repoRoot, output), { recursive: true, force: true });
-  }
   rmSync(temporaryRoot, { recursive: true, force: true });
 }
 
@@ -211,12 +215,12 @@ function verifyArtifacts() {
   const pythonBuildEnvironment = join(temporaryRoot, 'python-build');
   const pythonInstallEnvironment = join(temporaryRoot, 'python-install');
   run('mkdir', ['-p', npmOutput, pythonOutput]);
-  copyNpmPackageSources();
-  run('pnpm', ['-C', 'packages/aid', 'build']);
-  run('pnpm', ['-C', 'packages/aid-engine', 'build']);
-  run('pnpm', ['-C', 'packages/aid-doctor', 'build']);
-  run('pnpm', ['-C', 'packages/aid', 'pack', '--pack-destination', npmOutput]);
-  run('pnpm', ['-C', 'packages/aid-doctor', 'pack', '--pack-destination', npmOutput]);
+  const temporaryPackages = copyNpmPackageSources();
+  run('pnpm', ['-C', join(temporaryPackages, 'aid'), 'build']);
+  run('pnpm', ['-C', join(temporaryPackages, 'aid-engine'), 'build']);
+  run('pnpm', ['-C', join(temporaryPackages, 'aid-doctor'), 'build']);
+  run('pnpm', ['-C', join(temporaryPackages, 'aid'), 'pack', '--pack-destination', npmOutput]);
+  run('pnpm', ['-C', join(temporaryPackages, 'aid-doctor'), 'pack', '--pack-destination', npmOutput]);
 
   const aidArchive = findArchive(npmOutput, 'agentcommunity-aid-2.1.1.tgz');
   const doctorArchive = findArchive(npmOutput, 'agentcommunity-aid-doctor-2.1.1.tgz');

--- a/scripts/verify-package-claims.mjs
+++ b/scripts/verify-package-claims.mjs
@@ -1,0 +1,184 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+const repoRoot = resolve(import.meta.dirname, '..');
+const temporaryRoot = mkdtempSync(join(tmpdir(), 'aid-package-claims-'));
+const repository = 'https://github.com/agentcommunity/agent-identity-discovery';
+const homepage = 'https://aid.agentcommunity.org';
+const docs = 'https://aid.agentcommunity.org/docs';
+const securityContact = 'security@agentcommunity.org';
+const productionDomain = 'agentcommunity.org';
+
+function fail(message) {
+  throw new Error(`Package claim verification failed: ${message}`);
+}
+
+function expect(condition, message) {
+  if (!condition) fail(message);
+}
+
+function read(relativePath) {
+  return readFileSync(join(repoRoot, relativePath), 'utf8');
+}
+
+function readJson(relativePath) {
+  return JSON.parse(read(relativePath));
+}
+
+function run(command, args, options = {}) {
+  execFileSync(command, args, {
+    cwd: repoRoot,
+    stdio: 'inherit',
+    env: registrySafeEnvironment(options.env),
+    ...options,
+  });
+}
+
+function registrySafeEnvironment(overrides) {
+  const environment = { ...process.env };
+  for (const name of ['NPM_TOKEN', 'NODE_AUTH_TOKEN', 'PYPI_TOKEN', 'TWINE_PASSWORD', 'TWINE_USERNAME']) {
+    delete environment[name];
+  }
+
+  return {
+    ...environment,
+    NPM_CONFIG_USERCONFIG: join(temporaryRoot, 'npmrc'),
+    PIP_CONFIG_FILE: join(temporaryRoot, 'pip.conf'),
+    ...overrides,
+  };
+}
+
+function assertReadme(relativePath, packageName) {
+  const contents = read(relativePath);
+  expect(contents.includes(repository), `${relativePath} must link to ${repository}`);
+  expect(contents.includes(homepage), `${relativePath} must link to ${homepage}`);
+  expect(contents.includes(docs), `${relativePath} must link to ${docs}`);
+  expect(contents.includes(securityContact), `${relativePath} must include ${securityContact}`);
+  expect(contents.includes('SECURITY.md'), `${relativePath} must link to SECURITY.md`);
+  expect(contents.includes(packageName), `${relativePath} must use the exact package name ${packageName}`);
+  expect(contents.includes(productionDomain), `${relativePath} must include a ${productionDomain} production example`);
+}
+
+function assertNpmMetadata(relativePath, packageName) {
+  const manifest = readJson(relativePath);
+  expect(manifest.name === packageName, `${relativePath} name must be ${packageName}`);
+  expect(manifest.version === '2.1.1', `${relativePath} version must be 2.1.1`);
+  expect(manifest.repository?.url === repository, `${relativePath} repository must be canonical`);
+  expect(manifest.homepage === homepage, `${relativePath} homepage must be canonical`);
+  expect(manifest.bugs?.url === `${repository}/issues`, `${relativePath} bugs URL must be canonical`);
+  expect(manifest.license === 'MIT', `${relativePath} license must be MIT`);
+  expect(manifest.engines?.node === '>=18.17', `${relativePath} node engine must remain >=18.17`);
+}
+
+function assertTarEntries(archivePath, expectedEntries) {
+  const entries = execFileSync('tar', ['-tzf', archivePath], { encoding: 'utf8' });
+  for (const entry of expectedEntries) {
+    expect(entries.split('\n').includes(entry), `${archivePath} must contain ${entry}`);
+  }
+}
+
+function assertPythonArchiveEntries(archivePath, expectedSuffixes) {
+  const script = [
+    'import pathlib, sys, tarfile, zipfile',
+    'archive = pathlib.Path(sys.argv[1])',
+    'names = tarfile.open(archive).getnames() if archive.suffix == ".gz" else zipfile.ZipFile(archive).namelist()',
+    'for suffix in sys.argv[2:]:',
+    '    if not any(name.endswith(suffix) for name in names):',
+    '        raise SystemExit(f"missing {suffix} from {archive}")',
+  ].join('\n');
+  run('python3', ['-c', script, archivePath, ...expectedSuffixes]);
+}
+
+function findArchive(directory, suffix) {
+  const match = readdirSync(directory).find((entry) => entry.endsWith(suffix));
+  expect(match, `expected a ${suffix} artifact in ${directory}`);
+  return join(directory, match);
+}
+
+function verifySourceClaims() {
+  const rootReadme = read('README.md');
+  expect(existsSync(join(repoRoot, 'SECURITY.md')), 'root SECURITY.md must exist');
+  expect(read('SECURITY.md').includes(securityContact), 'SECURITY.md must name the security contact');
+  expect(rootReadme.includes(repository), 'README.md must link to the canonical repository');
+  expect(rootReadme.includes(homepage), 'README.md must link to the canonical product home');
+  expect(rootReadme.includes(docs), 'README.md must link to the canonical docs');
+  expect(rootReadme.includes(securityContact), 'README.md must include the security contact');
+  expect(rootReadme.includes('SECURITY.md'), 'README.md must link to SECURITY.md');
+  expect(!rootReadme.includes('not yet community-owned'), 'README.md must not claim aid-discovery is not community-owned');
+  expect(rootReadme.includes(productionDomain), 'README.md must include an agentcommunity.org production example');
+
+  assertNpmMetadata('packages/aid/package.json', '@agentcommunity/aid');
+  assertNpmMetadata('packages/aid-doctor/package.json', '@agentcommunity/aid-doctor');
+  assertReadme('packages/aid/README.md', '@agentcommunity/aid');
+  assertReadme('packages/aid-doctor/README.md', '@agentcommunity/aid-doctor');
+  assertReadme('packages/aid-py/README.md', 'aid-discovery');
+
+  const pythonProject = read('packages/aid-py/pyproject.toml');
+  expect(pythonProject.includes('name = "aid-discovery"'), 'Python project name must be aid-discovery');
+  expect(pythonProject.includes('version = "2.1.1"'), 'Python version must be 2.1.1');
+  expect(pythonProject.includes('requires-python = ">=3.8"'), 'Python must keep >=3.8 support');
+  expect(pythonProject.includes('license = { file = "LICENSE" }'), 'Python must use the package-local LICENSE metadata');
+  expect(pythonProject.includes(`Documentation = "${docs}"`), 'Python documentation URL must be canonical');
+  expect(read('packages/aid-py/LICENSE') === read('LICENSE'), 'Python LICENSE must match root LICENSE');
+
+  const webPackage = readJson('packages/web/package.json');
+  expect(webPackage.scripts.test === 'pnpm gen:content && vitest run', 'web test must generate its ignored content first');
+}
+
+function verifyArtifacts() {
+  const npmOutput = join(temporaryRoot, 'npm');
+  const pythonOutput = join(temporaryRoot, 'python');
+  const pythonSource = join(temporaryRoot, 'python-source');
+  const pythonBuildEnvironment = join(temporaryRoot, 'python-build');
+  const pythonInstallEnvironment = join(temporaryRoot, 'python-install');
+  run('mkdir', ['-p', npmOutput, pythonOutput]);
+  run('pnpm', ['-C', 'packages/aid', 'build']);
+  run('pnpm', ['-C', 'packages/aid-engine', 'build']);
+  run('pnpm', ['-C', 'packages/aid-doctor', 'build']);
+  run('pnpm', ['-C', 'packages/aid', 'pack', '--pack-destination', npmOutput]);
+  run('pnpm', ['-C', 'packages/aid-doctor', 'pack', '--pack-destination', npmOutput]);
+
+  const aidArchive = findArchive(npmOutput, 'agentcommunity-aid-2.1.1.tgz');
+  const doctorArchive = findArchive(npmOutput, 'agentcommunity-aid-doctor-2.1.1.tgz');
+  assertTarEntries(aidArchive, ['package/README.md', 'package/LICENSE']);
+  assertTarEntries(doctorArchive, ['package/README.md', 'package/LICENSE']);
+
+  const aidInstall = join(temporaryRoot, 'npm-aid');
+  const doctorInstall = join(temporaryRoot, 'npm-doctor');
+  run('npm', ['install', '--ignore-scripts', '--no-audit', '--no-fund', '--prefix', aidInstall, aidArchive]);
+  run('node', [
+    '--input-type=module',
+    '--eval',
+    `import { discover } from '@agentcommunity/aid'; const result = await discover('${productionDomain}'); if (!result.record?.uri) throw new Error('AID discovery returned no URI');`,
+  ], { cwd: aidInstall });
+  run('npm', ['install', '--ignore-scripts', '--no-audit', '--no-fund', '--prefix', doctorInstall, doctorArchive]);
+  run('node', ['node_modules/@agentcommunity/aid-doctor/dist/cli.js', 'check', productionDomain], { cwd: doctorInstall });
+
+  run('python3', ['-m', 'venv', pythonBuildEnvironment]);
+  const buildPython = join(pythonBuildEnvironment, 'bin', 'python');
+  run('cp', ['-R', 'packages/aid-py', pythonSource]);
+  run(buildPython, ['-m', 'pip', 'install', '--disable-pip-version-check', 'build']);
+  run(buildPython, ['-m', 'build', '--sdist', '--wheel', '--outdir', pythonOutput, pythonSource]);
+  const sdist = findArchive(pythonOutput, '.tar.gz');
+  const wheel = findArchive(pythonOutput, '.whl');
+  assertPythonArchiveEntries(sdist, ['LICENSE', 'README.md']);
+  assertPythonArchiveEntries(wheel, ['LICENSE', 'README.md']);
+
+  run('python3', ['-m', 'venv', pythonInstallEnvironment]);
+  const installPython = join(pythonInstallEnvironment, 'bin', 'python');
+  run(installPython, ['-m', 'pip', 'install', '--disable-pip-version-check', wheel]);
+  run(installPython, [
+    '-c',
+    `from aid_py import discover; record, _ = discover('${productionDomain}'); assert record['uri']`,
+  ]);
+}
+
+try {
+  verifySourceClaims();
+  verifyArtifacts();
+  console.log('Package claims and artifacts verified.');
+} finally {
+  rmSync(temporaryRoot, { recursive: true, force: true });
+}

--- a/scripts/verify-package-claims.test.mjs
+++ b/scripts/verify-package-claims.test.mjs
@@ -1,11 +1,74 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import test from 'node:test';
 import { join, resolve } from 'node:path';
+import { readPythonWheelLicense } from './package-claim-archive.mjs';
 
 const repoRoot = resolve(import.meta.dirname, '..');
 const verifier = readFileSync(join(repoRoot, 'scripts/verify-package-claims.mjs'), 'utf8');
 const pythonReadme = readFileSync(join(repoRoot, 'packages/aid-py/README.md'), 'utf8');
+
+function createWheel(entries) {
+  const directory = mkdtempSync(join(tmpdir(), 'aid-wheel-license-fixture-'));
+  const archive = join(directory, 'fixture.whl');
+  const encodedEntries = Buffer.from(JSON.stringify(entries)).toString('base64');
+  const script = [
+    'import base64, json, sys, zipfile',
+    'entries = json.loads(base64.b64decode(sys.argv[2]))',
+    'with zipfile.ZipFile(sys.argv[1], "w") as archive:',
+    '    for name, contents in entries:',
+    '        archive.writestr(name, contents)',
+  ].join('\n');
+  execFileSync('python3', ['-c', script, archive, encodedEntries], { stdio: 'pipe' });
+  return { archive, directory };
+}
+
+function withWheel(entries, callback) {
+  const fixture = createWheel(entries);
+  try {
+    callback(fixture.archive);
+  } finally {
+    rmSync(fixture.directory, { recursive: true, force: true });
+  }
+}
+
+test('reads the exact wheel license bytes from each supported setuptools layout', () => {
+  const expectedLicense = 'MIT fixture license\n';
+  for (const licenseEntry of [
+    'aid_discovery-2.1.1.dist-info/LICENSE',
+    'aid_discovery-2.1.1.dist-info/licenses/LICENSE',
+  ]) {
+    withWheel([[licenseEntry, expectedLicense]], (archive) => {
+      assert.equal(readPythonWheelLicense(archive), expectedLicense);
+    });
+  }
+});
+
+test('rejects a wheel with no supported license entry', () => {
+  withWheel([['aid_discovery-2.1.1.dist-info/METADATA', 'Name: aid-discovery\n']], (archive) => {
+    assert.throws(() => readPythonWheelLicense(archive), /expected exactly one supported wheel license entry/);
+  });
+});
+
+test('rejects wheel license entries that are duplicate or ambiguous', () => {
+  const layouts = [
+    [
+      ['aid_discovery-2.1.1.dist-info/LICENSE', 'first\n'],
+      ['aid_discovery-2.1.1.dist-info/LICENSE', 'second\n'],
+    ],
+    [
+      ['aid_discovery-2.1.1.dist-info/LICENSE', 'legacy\n'],
+      ['aid_discovery-2.1.1.dist-info/licenses/LICENSE', 'pep-639\n'],
+    ],
+  ];
+  for (const entries of layouts) {
+    withWheel(entries, (archive) => {
+      assert.throws(() => readPythonWheelLicense(archive), /expected exactly one supported wheel license entry/);
+    });
+  }
+});
 
 test('verifier isolates all pip operations and builds npm artifacts outside the checkout', () => {
   assert.match(verifier, /--isolated/);

--- a/scripts/verify-package-claims.test.mjs
+++ b/scripts/verify-package-claims.test.mjs
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
-import { execFileSync } from 'node:child_process';
-import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, readdirSync, rmSync, statSync } from 'node:fs';
+import { createHash } from 'node:crypto';
 import { tmpdir } from 'node:os';
 import test from 'node:test';
 import { join, resolve } from 'node:path';
@@ -33,6 +34,43 @@ function withWheel(entries, callback) {
     rmSync(fixture.directory, { recursive: true, force: true });
   }
 }
+
+function hashTree(directory) {
+  const hash = createHash('sha256');
+  function visit(relativePath) {
+    const absolutePath = join(directory, relativePath);
+    const entries = readdirSync(absolutePath, { withFileTypes: true }).sort(function (left, right) {
+      return left.name.localeCompare(right.name);
+    });
+    for (const entry of entries) {
+      const childRelativePath = join(relativePath, entry.name);
+      const childAbsolutePath = join(directory, childRelativePath);
+      if (entry.isDirectory()) {
+        hash.update(`directory:${childRelativePath}\n`);
+        visit(childRelativePath);
+      } else {
+        const contents = readFileSync(childAbsolutePath);
+        hash.update(`file:${childRelativePath}:${statSync(childAbsolutePath).mode}:${contents.length}\n`);
+        hash.update(contents);
+      }
+    }
+  }
+  visit('.');
+  return hash.digest('hex');
+}
+
+test('verifier preserves a prior aid build output while it verifies package claims', () => {
+  const packageDirectory = join(repoRoot, 'packages/aid');
+  const distDirectory = join(packageDirectory, 'dist');
+  execFileSync('pnpm', ['-C', packageDirectory, 'build'], { cwd: repoRoot, stdio: 'pipe' });
+  const before = hashTree(distDirectory);
+  const verification = spawnSync('node', ['scripts/verify-package-claims.mjs'], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  });
+  assert.equal(verification.status, 0, verification.stderr);
+  assert.equal(hashTree(distDirectory), before);
+});
 
 test('reads the exact wheel license bytes from each supported setuptools layout', () => {
   const expectedLicense = 'MIT fixture license\n';
@@ -73,12 +111,14 @@ test('rejects wheel license entries that are duplicate or ambiguous', () => {
 test('verifier isolates all pip operations and builds npm artifacts outside the checkout', () => {
   assert.match(verifier, /--isolated/);
   assert.match(verifier, /copyNpmPackageSources/);
+  assert.match(verifier, /const npmPackages = \['aid', 'aid-engine', 'aid-doctor'\]/);
+  assert.match(verifier, /symlinkSync\(join\(repoRoot, 'node_modules'\), join\(temporaryRoot, 'node_modules'\), 'dir'\)/);
+  assert.match(verifier, /path !== join\(source, 'dist'\)/);
   assert.match(verifier, /NPM_CONFIG_USERCONFIG/);
   assert.match(verifier, /PIP_CONFIG_FILE/);
   assert.match(verifier, /const \{ env: _ignoredEnvironment, \.\.\.runOptions \} = options;/);
   assert.match(verifier, /\.\.\.runOptions,\s*env: registrySafeEnvironment\(\)/);
-  assert.match(verifier, /let verifierCheckoutOutputs = \[\];/);
-  assert.match(verifier, /verifierCheckoutOutputs = checkoutOutputs;/);
+  assert.doesNotMatch(verifier, /refusing to overwrite pre-existing/);
 });
 
 test('verifier checks packed README, license, and metadata bytes', () => {

--- a/scripts/verify-package-claims.test.mjs
+++ b/scripts/verify-package-claims.test.mjs
@@ -113,7 +113,7 @@ test('verifier isolates all pip operations and builds npm artifacts outside the 
   assert.match(verifier, /copyNpmPackageSources/);
   assert.match(verifier, /const npmPackages = \['aid', 'aid-engine', 'aid-doctor'\]/);
   assert.match(verifier, /symlinkSync\(join\(repoRoot, 'node_modules'\), join\(temporaryRoot, 'node_modules'\), 'dir'\)/);
-  assert.match(verifier, /path !== join\(source, 'dist'\)/);
+  assert.match(verifier, /copyPackageWorkspace/);
   assert.match(verifier, /NPM_CONFIG_USERCONFIG/);
   assert.match(verifier, /PIP_CONFIG_FILE/);
   assert.match(verifier, /const \{ env: _ignoredEnvironment, \.\.\.runOptions \} = options;/);

--- a/scripts/verify-package-claims.test.mjs
+++ b/scripts/verify-package-claims.test.mjs
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+import { join, resolve } from 'node:path';
+
+const repoRoot = resolve(import.meta.dirname, '..');
+const verifier = readFileSync(join(repoRoot, 'scripts/verify-package-claims.mjs'), 'utf8');
+const pythonReadme = readFileSync(join(repoRoot, 'packages/aid-py/README.md'), 'utf8');
+
+test('verifier isolates all pip operations and builds npm artifacts outside the checkout', () => {
+  assert.match(verifier, /--isolated/);
+  assert.match(verifier, /copyNpmPackageSources/);
+  assert.match(verifier, /NPM_CONFIG_USERCONFIG/);
+  assert.match(verifier, /PIP_CONFIG_FILE/);
+  assert.match(verifier, /const \{ env: _ignoredEnvironment, \.\.\.runOptions \} = options;/);
+  assert.match(verifier, /\.\.\.runOptions,\s*env: registrySafeEnvironment\(\)/);
+  assert.match(verifier, /let verifierCheckoutOutputs = \[\];/);
+  assert.match(verifier, /verifierCheckoutOutputs = checkoutOutputs;/);
+});
+
+test('verifier checks packed README, license, and metadata bytes', () => {
+  assert.match(verifier, /readTarEntry/);
+  assert.match(verifier, /readPythonArchiveEntry/);
+  assert.match(verifier, /assertPackagedReadme/);
+  assert.match(verifier, /assertPackagedLicense/);
+  assert.match(verifier, /assertPackagedMetadata/);
+});
+
+test('Python package documents the real agentcommunity.org production endpoint', () => {
+  assert.match(pythonReadme, /https:\/\/agentcommunity\.org\/mcp/);
+  assert.doesNotMatch(pythonReadme, /https:\/\/api\.supabase\.com\/mcp/);
+});
+
+test('Python package documents the immutable-version release gate', () => {
+  assert.match(pythonReadme, /2\.1\.1 is immutable/);
+  assert.match(pythonReadme, /next `aid-discovery` patch version/);
+  assert.match(pythonReadme, /coordinate PAGE/);
+});


### PR DESCRIPTION
## What changed

- make the JavaScript and Python package claims reproducible from packed artifacts
- verify package contents, metadata, clean installs, and a bounded live operation
- include license artifacts and cover both current and legacy Python wheel license layouts
- document publication and provenance boundaries without claiming an unpublished release

## Why

The Ora technical-layer plan requires every advertised SDK claim to be independently verifiable. This keeps source readiness, registry publication, provenance, and live behavior as separate states.

## Validation

- pnpm test
- pnpm build
- pnpm lint
- pnpm docs:verify
- focused archive and package-claim verification recorded in the plan ledger

No package was published and no production deployment was performed by this PR.